### PR TITLE
e2e: add handler for SA Authorize access page

### DIFF
--- a/e2e/app.po.ts
+++ b/e2e/app.po.ts
@@ -128,17 +128,9 @@ export class AppPage {
 
   async login(user: User): P<any> {
     // need to disable angular wait before check for current url because we're being redirected outside of angular
-    browser.waitForAngular()
-      .then(() => {
-        log.info('Landed on Angular page, continue with tests');
-        return P.resolve;
-    })
-      .catch(() => {
-        log.info('Wait for Angular failed, continue with login processs');
-    });
-    await this.goToUrl(AppPage.baseurl);
-    
     browser.waitForAngularEnabled(false);
+    await this.goToUrl(AppPage.baseurl);
+
     let currentUrl = await browser.getCurrentUrl();
     if (contains(currentUrl, 'github.com/login')) {
       log.info('GitHub login page');

--- a/e2e/app.po.ts
+++ b/e2e/app.po.ts
@@ -3,7 +3,7 @@ import * as webdriver from 'selenium-webdriver';
 import { Promise as P } from 'es6-promise';
 import { User, UserDetails } from './common/common';
 import { contains } from './common/world';
-import { GithubLogin, KeycloakDetails } from './login/login.po';
+import { GithubLogin, KeycloakDetails, OpenShiftAuthorize } from './login/login.po';
 import { log } from '../src/app/logging';
 import * as jQuery from 'jquery';
 import WebElement = webdriver.WebElement;
@@ -128,14 +128,26 @@ export class AppPage {
 
   async login(user: User): P<any> {
     // need to disable angular wait before check for current url because we're being redirected outside of angular
-    browser.waitForAngularEnabled(false);
-
+    browser.waitForAngular()
+      .then(() => {
+        log.info('Landed on Angular page, continue with tests');
+        return P.resolve;
+    })
+      .catch(() => {
+        log.info('Wait for Angular failed, continue with login processs');
+    });
     await this.goToUrl(AppPage.baseurl);
-
+    
+    browser.waitForAngularEnabled(false);
     let currentUrl = await browser.getCurrentUrl();
     if (contains(currentUrl, 'github.com/login')) {
       log.info('GitHub login page');
       await new GithubLogin().login(user);
+    }
+    currentUrl = await browser.getCurrentUrl();
+    if (contains(currentUrl, 'oauth/authorize/approve')) {
+      log.info('Authorize access login page');
+      await new OpenShiftAuthorize().authorizeAccess();
     }
     currentUrl = await browser.getCurrentUrl();
     if (contains(currentUrl, 'auth/realms')) {

--- a/e2e/login/login.po.ts
+++ b/e2e/login/login.po.ts
@@ -53,6 +53,17 @@ export class GithubLogin implements LoginPage {
   }
 }
 
+export class OpenShiftAuthorize {
+
+  submitSelector = 'input[name="approve"]';
+
+  async authorizeAccess(): P<any> {
+    const submitButton = element(by.css(this.submitSelector));
+    browser.wait(ExpectedConditions.presenceOf(submitButton), 10000, 'Wait for submit button');
+    return submitButton.getWebElement().click();
+  }
+}
+
 export class KeycloakDetails {
 
   loginSelector = 'input#username';


### PR DESCRIPTION
On a clean deployment, there's yet another `Authorize Access` (ServiceAccount asking to access user info) page that needs to be submitted. This PR should handle this page.

Also I've added a bit `waitForAngular()` magic [here](https://github.com/syndesisio/syndesis-ui/compare/master...dsimansk:e2e-fixes?expand=1#diff-6fe650a8e21fe8d744c835bf070922f3R133), to improve stability. 