### PR TITLE
Filter Step (Basic) - Initial Run-Through

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ The repo is commitizen friendly, after making some changes:
 
 `yarn commit`
 
-to commit them
+to commit them. `yarn commit` is the same as running `git cz` in this case. So, you can use all the git commit options, 
+for example: `yarn commit -am 'Blah blah blah''`.
+
+Don't forget to add your files to staging first with `git add -A`. This is a `git commit` tool, not a total `git` replacement.
 
 #### Production
 *Requires having `angular-cli` installed globally.*

--- a/src/app/integrations/edit-page/current-flow.service.ts
+++ b/src/app/integrations/edit-page/current-flow.service.ts
@@ -228,6 +228,15 @@ export class CurrentFlow {
     // log.debugc(() => 'integration: ' + JSON.stringify(this._integration, undefined, 2), category);
   }
 
+  /**
+   * Function to retrieve the form data for the basic filter
+   * @returns {Observable<any>}
+   * @memberof CurrentFlow
+   */
+  getFilterOptions(): Observable<any> {
+    return this.store.service.restangularService.one('filters').one('options').get();
+  }
+
   getIntegrationClone(): Integration {
     return JSON.parse(JSON.stringify(this.integration));
   }

--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.html
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.html
@@ -7,9 +7,9 @@
 
     <p>Fill out the fields associated with the selected step.</p>
 
-    <div class="overflow-hidden content-margin container-fluid">
+    <div class="overflow-hidden content-margin basic-filter-form-container">
 
-      <form [formGroup]="formGroup">
+      <form [formGroup]="formGroup" class="basic-filter-form">
 
         <dynamic-form-bootstrap-control *ngFor="let controlModel of basicFilterModel"
                                         [group]="formGroup"
@@ -21,16 +21,11 @@
                        let-index="index">
 
             <div class="pull-right">
-
               <button type="button"
+                      *ngIf="index !== 0"
                       class="btn btn-danger btn-sm rounded"
                       (click)="remove(context, index)">&#10005;
               </button>
-              <button type="button"
-                      class="btn btn-success btn-sm rounded"
-                      (click)="insert(context, index + 1)">&#43;
-              </button>
-
             </div>
 
           </ng-template>
@@ -39,9 +34,7 @@
 
       </form>
 
-      <!--button (click)="test()" type="button">Test</button-->
-
-      <pre>{{formGroup.value | json}}</pre>
+      <button (click)="add()" type="button">Add</button>
 
     </div>
   </div>

--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.html
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.html
@@ -1,0 +1,48 @@
+<div class="basic-filter">
+  <div class="clearfix">
+
+    <div class="title">
+      <h1>Configure Basic Filter Step</h1>
+    </div>
+
+    <p>Fill out the fields associated with the selected step.</p>
+
+    <div class="overflow-hidden content-margin container-fluid">
+
+      <form [formGroup]="formGroup">
+
+        <dynamic-form-bootstrap-control *ngFor="let controlModel of basicFilterModel"
+                                        [group]="formGroup"
+                                        [model]="controlModel"
+                                        (change)="onChange($event)">
+
+          <ng-template modelId="rulesFormArray"
+                       let-context="context"
+                       let-index="index">
+
+            <div class="pull-right">
+
+              <button type="button"
+                      class="btn btn-danger btn-sm rounded"
+                      (click)="remove(context, index)">&#10005;
+              </button>
+              <button type="button"
+                      class="btn btn-success btn-sm rounded"
+                      (click)="insert(context, index + 1)">&#43;
+              </button>
+
+            </div>
+
+          </ng-template>
+
+        </dynamic-form-bootstrap-control>
+
+      </form>
+
+      <!--button (click)="test()" type="button">Test</button-->
+
+      <pre>{{formGroup.value | json}}</pre>
+
+    </div>
+  </div>
+</div>

--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.scss
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.scss
@@ -1,0 +1,20 @@
+.basic-filter {
+  .basic-filter-form-container {
+    background: #FFFFFF;
+    padding: 30px;
+
+    .basic-filter-form {
+      .rules-group {
+        .form-group {
+          padding: 10px 0;
+
+          .input-group {
+            .input-group-addon {
+              cursor: pointer;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.ts
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.ts
@@ -7,6 +7,8 @@ import {
   DynamicInputModel,
 } from '@ng2-dynamic-forms/core';
 
+import { CurrentFlow, FlowEvent } from '../../current-flow.service';
+
 import { BASIC_FILTER_MODEL } from './basic-filter.model';
 import { log, getCategory } from '../../../../logging';
 import { BasicFilter } from './filter.interface';
@@ -15,6 +17,7 @@ import { BasicFilter } from './filter.interface';
   selector: 'syndesis-basic-filter',
   templateUrl: './basic-filter.component.html',
   encapsulation: ViewEncapsulation.None,
+  styleUrls: ['./basic-filter.component.scss'],
 })
 
 export class BasicFilterComponent implements OnInit {
@@ -51,16 +54,24 @@ export class BasicFilterComponent implements OnInit {
   };
   @Output() filterChange = new EventEmitter<BasicFilter>();
 
-  constructor(private formService: DynamicFormService) {
+  constructor(public currentFlow: CurrentFlow,
+              private formService: DynamicFormService) {
   }
 
   ngOnInit() {
+    /*
+    this.currentFlow.getFilterOptions().toPromise().then((resp:any) => {
+      log.debugc(
+        () => 'filter option response: ' + resp,
+      );
+    });
+    */
     this.formGroup = this.formService.createFormGroup(this.basicFilterModel);
 
     this.exampleControl = this.formGroup.get('filterSettingsGroup').get('matchSelect') as FormControl;
     this.exampleModel = this.formService.findById('matchSelect', this.basicFilterModel) as DynamicInputModel;
 
-    this.arrayControl = this.formGroup.get('rulesGroup').get('bootstrapFormArray') as FormArray;
+    this.arrayControl = this.formGroup.get('rulesGroup').get('rulesFormArray') as FormArray;
     this.arrayModel = this.formService.findById('rulesFormArray', this.basicFilterModel) as DynamicFormArrayModel;
   }
 

--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.ts
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.ts
@@ -1,0 +1,106 @@
+import { Component, EventEmitter, Input, OnInit, Output, ViewEncapsulation } from '@angular/core';
+import { FormGroup, FormControl, FormArray } from '@angular/forms';
+import {
+  DynamicFormService,
+  DynamicFormControlModel,
+  DynamicFormArrayModel,
+  DynamicInputModel,
+} from '@ng2-dynamic-forms/core';
+
+import { BASIC_FILTER_MODEL } from './basic-filter.model';
+import { log, getCategory } from '../../../../logging';
+import { BasicFilter } from './filter.interface';
+
+@Component({
+  selector: 'syndesis-basic-filter',
+  templateUrl: './basic-filter.component.html',
+  encapsulation: ViewEncapsulation.None,
+})
+
+export class BasicFilterComponent implements OnInit {
+
+  basicFilterModel: DynamicFormControlModel[] = BASIC_FILTER_MODEL;
+  formGroup: FormGroup;
+
+  exampleControl: FormControl;
+  exampleModel: DynamicInputModel;
+
+  arrayControl: FormArray;
+  arrayModel: DynamicFormArrayModel;
+
+  @Input()
+  basicFilterObject: BasicFilter = {
+    'id': '1',
+    'stepKind': 'filter',
+    'configuredProperties': {
+      'type': 'rule',
+      'predicate': 'AND',
+      'simple' : '${body} contains \'antman\' || ${in.header.publisher} =~ \'DC Comics\'',
+      'rules' : [
+        {
+          'path': 'body.text',
+          'value': 'antman',
+        },
+        {
+          'path': 'header.kind',
+          'op': '=~',
+          'value': 'DC Comics',
+        },
+      ],
+    },
+  };
+  @Output() filterChange = new EventEmitter<BasicFilter>();
+
+  constructor(private formService: DynamicFormService) {
+  }
+
+  ngOnInit() {
+    this.formGroup = this.formService.createFormGroup(this.basicFilterModel);
+
+    this.exampleControl = this.formGroup.get('filterSettingsGroup').get('matchSelect') as FormControl;
+    this.exampleModel = this.formService.findById('matchSelect', this.basicFilterModel) as DynamicInputModel;
+
+    this.arrayControl = this.formGroup.get('rulesGroup').get('bootstrapFormArray') as FormArray;
+    this.arrayModel = this.formService.findById('rulesFormArray', this.basicFilterModel) as DynamicFormArrayModel;
+  }
+
+  // Manage Individual Fields
+  add() {
+    this.formService.addFormArrayGroup(this.arrayControl, this.arrayModel);
+  }
+
+  insert(context: DynamicFormArrayModel, index: number) {
+    this.formService.insertFormArrayGroup(index, this.arrayControl, context);
+    log.debugc(
+      () => 'basicFilterModel: ' + this.basicFilterModel,
+    );
+  }
+
+  remove(context: DynamicFormArrayModel, index: number) {
+    this.formService.removeFormArrayGroup(index, this.arrayControl, context);
+  }
+
+  clear() {
+    this.formService.clearFormArray(this.arrayControl, this.arrayModel);
+  }
+
+  onBlur($event) {
+    log.debugc(
+      () => 'BLUR event on $(event.model.id): ' + $event,
+    );
+  }
+
+  onChange($event) {
+    this.basicFilterObject = $event.value;
+    this.filterChange.emit(this.basicFilterObject);
+    log.debugc(
+      () => 'CHANGE event on $(event.model.id): ' + $event,
+    );
+  }
+
+  onFocus($event) {
+    log.debugc(
+      () => 'FOCUS event on $(event.model.id): ' + $event,
+    );
+  }
+}

--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.model.ts
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.model.ts
@@ -32,7 +32,7 @@ export const BASIC_FILTER_MODEL = [
             label: 'control-label pull-left',
           },
           grid: {
-            control: 'col-xs-3',
+            control: 'col-xs-3 match-select',
           },
         },
       ),
@@ -121,7 +121,7 @@ export const BASIC_FILTER_MODEL = [
         },
         {
           element: {
-            container: 'form-inline form-array',
+            container: 'form-inline form-array rules-group',
           },
         },
       ),

--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.model.ts
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.model.ts
@@ -1,0 +1,130 @@
+import {
+  DynamicInputModel,
+  DynamicSelectModel,
+  DynamicFormArrayModel,
+  DynamicFormGroupModel,
+} from '@ng2-dynamic-forms/core';
+import { Observable } from 'rxjs/Observable';
+
+export const BASIC_FILTER_MODEL = [
+
+  new DynamicFormGroupModel({
+    id: 'filterSettingsGroup',
+    group: [
+      new DynamicSelectModel<string>(
+        {
+          id: 'matchSelect',
+          label: 'Continue only if incoming data match ',
+          options: Observable.of([
+            {
+              label: 'ALL of the following',
+              value: 'all',
+            },
+            {
+              label: 'ANY of the following',
+              value: 'any',
+            },
+          ]),
+          value: 'all',
+        },
+        {
+          element: {
+            label: 'control-label pull-left',
+          },
+          grid: {
+            control: 'col-xs-3',
+          },
+        },
+      ),
+    ],
+  }),
+
+  new DynamicFormGroupModel({
+    id: 'rulesGroup',
+    group: [
+      new DynamicFormArrayModel(
+        {
+          id: 'rulesFormArray',
+          initialCount: 5,
+          groupFactory: () => {
+            return [
+              new DynamicInputModel(
+                {
+                  id: 'dataToBeFiltered',
+                  maxLength: 51,
+                  placeholder: 'Status.Text',
+                  suffix: 'Browse...', // This is just a suffix; this whole field needs to change
+                },
+                {
+                  element: {
+                    container: 'form-group col-xs-3',
+                  },
+                  grid: {
+                    control: 'input-group',
+                  },
+                },
+              ),
+              new DynamicSelectModel<string>(
+                {
+                  id: 'conditions',
+                  options: Observable.of([
+                    {
+                      label: 'Contains',
+                      value: 'contains',
+                    },
+                    {
+                      label: 'Does Not Contain',
+                      value: 'does-not-contain',
+                    },
+                    {
+                      label: 'Matches Regex',
+                      value: 'matches-regex',
+                    },
+                    {
+                      label: 'Does Not Match Regex',
+                      value: 'does-not-match-regex',
+                    },
+                    {
+                      label: 'Starts With',
+                      value: 'starts-with',
+                    },
+                    {
+                      label: 'Ends With',
+                      value: 'ends-with',
+                    },
+                  ]),
+                  value: 'contains',
+                },
+                {
+                  element: {
+                    container: 'form-group col-xs-3',
+                    label: 'control-label',
+                  },
+                  grid: {
+                    control: 'input-group',
+                  },
+                },
+              ),
+              new DynamicInputModel(
+                {
+                  id: 'valueToCheckFor',
+                  placeholder: 'e.g. Red Hat',
+                },
+                {
+                  grid: {
+                    container: 'input-group',
+                  },
+                },
+              ),
+            ];
+          },
+        },
+        {
+          element: {
+            container: 'form-inline form-array',
+          },
+        },
+      ),
+    ],
+  }),
+];

--- a/src/app/integrations/edit-page/step-configure/filter-steps/filter.interface.ts
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/filter.interface.ts
@@ -1,0 +1,16 @@
+export interface BasicFilter {
+  id?: string;
+  stepKind: string;
+  configuredProperties: {
+    type: string;
+    predicate: string;
+    simple: string;
+    rules?: Rule[];
+  };
+}
+
+export interface Rule {
+  path: string;
+  op?: string;
+  value: string;
+}

--- a/src/app/integrations/edit-page/step-configure/step-configure.component.html
+++ b/src/app/integrations/edit-page/step-configure/step-configure.component.html
@@ -35,6 +35,13 @@
             </div>
           </div>
         </div>
+        <div *ngSwitchCase="'basic-filter'">
+          <div class="row">
+            <div class="col-md-12">
+              <syndesis-basic-filter [basicFilterObject]="filterForm"></syndesis-basic-filter>
+            </div>
+          </div>
+        </div>
         <div *ngSwitchDefault>
           <div class="title">
             <h1>Configure {{ step.stepKind }}</h1>

--- a/src/app/integrations/edit-page/step-configure/step-configure.component.ts
+++ b/src/app/integrations/edit-page/step-configure/step-configure.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { FormGroup } from '@angular/forms';
@@ -19,7 +19,7 @@ const category = getCategory('IntegrationsCreatePage');
 @Component({
   selector: 'syndesis-integrations-step-configure',
   templateUrl: './step-configure.component.html',
-  styleUrls: ['./step-configure.component.scss'],
+  styleUrls: [ './step-configure.component.scss' ],
 })
 export class IntegrationsStepConfigureComponent extends FlowPage
   implements OnInit, OnDestroy {
@@ -30,16 +30,17 @@ export class IntegrationsStepConfigureComponent extends FlowPage
   formGroup: FormGroup;
   formConfig: any;
   cfg: any = undefined;
+  //filterForm: any;
 
-  constructor(
-    public currentFlow: CurrentFlow,
-    public route: ActivatedRoute,
-    public router: Router,
-    public formFactory: FormFactoryService,
-    public formService: DynamicFormService,
-    public detector: ChangeDetectorRef,
-    public stepStore: StepStore,
-  ) {
+  @Input() filterForm: any;
+
+  constructor(public currentFlow: CurrentFlow,
+              public route: ActivatedRoute,
+              public router: Router,
+              public formFactory: FormFactoryService,
+              public formService: DynamicFormService,
+              public detector: ChangeDetectorRef,
+              public stepStore: StepStore) {
     super(currentFlow, route, router, detector);
   }
 
@@ -47,17 +48,22 @@ export class IntegrationsStepConfigureComponent extends FlowPage
     const step = this.currentFlow.getStep(this.position);
     step.stepKind = undefined;
     step.configuredProperties = undefined;
-    super.goBack(['step-select', this.position]);
+    super.goBack([ 'step-select', this.position ]);
   }
 
   continue(data: any) {
     const step = this.currentFlow.getStep(this.position);
-    if (step.stepKind === 'mapper') {
-      this.router.navigate(['save-or-add-step'], {
-        queryParams: { validate: true },
-        relativeTo: this.route.parent,
-      });
-      return;
+    switch (step.stepKind) {
+      case 'mapper':
+        this.router.navigate([ 'save-or-add-step' ], {
+          queryParams: { validate: true },
+          relativeTo: this.route.parent,
+        });
+        return;
+    }
+    if (this.filterForm) {
+      data = this.filterForm;
+      log.debugc(() => 'Filterform: ' + data);
     }
     if (!data) {
       data = this.formGroup.value || {};
@@ -67,14 +73,14 @@ export class IntegrationsStepConfigureComponent extends FlowPage
       if (!data.hasOwnProperty(key)) {
         continue;
       }
-      properties[key] = data[key];
+      properties[ key ] = data[ key ];
     }
     this.currentFlow.events.emit({
       kind: 'integration-set-properties',
       position: this.position,
       properties: properties,
       onSave: () => {
-        this.router.navigate(['save-or-add-step'], {
+        this.router.navigate([ 'save-or-add-step' ], {
           queryParams: { validate: true },
           relativeTo: this.route.parent,
         });
@@ -84,6 +90,8 @@ export class IntegrationsStepConfigureComponent extends FlowPage
 
   getToolbarClass() {
     switch (this.currentFlow.getStep(this.position).stepKind) {
+      case 'basic-filter':
+        return 'toolbar basic-filter';
       case 'mapper':
         return 'toolbar mapper';
     }
@@ -106,16 +114,28 @@ export class IntegrationsStepConfigureComponent extends FlowPage
         const step = (this.step = <Step>this.currentFlow.getStep(
           this.position,
         ));
+
+        // If no Step exists, redirect to the Select Step view
         if (!step) {
-          this.router.navigate(['step-select', this.position], {
+          this.router.navigate([ 'step-select', this.position ], {
             relativeTo: this.route.parent,
           });
           return;
         }
+
+        // Step exists, get its configuration
         const stepDef = this.stepStore.getStepConfig(step.stepKind);
-        if (!stepDef || step.stepKind === 'mapper') {
+        log.debugc(
+          () => 'stepConfig: ' + JSON.stringify(stepDef),
+        );
+        if (!stepDef) {
           // TODO if we don't have a definition for this step then ???
-          return;
+          switch (step.stepKind) {
+            case 'basic-filter':
+            case 'mapper':
+              log.debugc(() => 'No form configuration, skipping the form building service..');
+              return;
+          }
         }
         this.formConfig = JSON.parse(JSON.stringify(stepDef.properties));
         const values: any = this.getConfiguredProperties(
@@ -126,11 +146,11 @@ export class IntegrationsStepConfigureComponent extends FlowPage
             continue;
           }
           // TODO hack to handle an unconfigured step
-          const value = values[key];
+          const value = values[ key ];
           if (typeof value === 'object') {
             continue;
           }
-          const item = this.formConfig[key];
+          const item = this.formConfig[ key ];
           if (item) {
             item.value = value;
           }
@@ -143,8 +163,11 @@ export class IntegrationsStepConfigureComponent extends FlowPage
           () => 'Form config: ' + JSON.stringify(this.formConfig, undefined, 2),
           category,
         );
+
+        // Call formService to build the form
         this.formModel = this.formFactory.createFormModel(this.formConfig);
         this.formGroup = this.formService.createFormGroup(this.formModel);
+
         setTimeout(() => {
           this.detector.detectChanges();
         }, 30);

--- a/src/app/integrations/edit-page/step-select/step-select.component.ts
+++ b/src/app/integrations/edit-page/step-select/step-select.component.ts
@@ -44,6 +44,8 @@ export class IntegrationsStepSelectComponent extends FlowPage
         return 'Log';
       case 'mapper':
         return 'Data Mapper';
+      case 'basic-filter':
+        return 'Basic Filter';
       default:
         // TODO not ideal
         return step.stepKind;
@@ -59,6 +61,11 @@ export class IntegrationsStepSelectComponent extends FlowPage
         return "Sends a message to the integration's log";
       case 'mapper':
         return 'Map fields from the input type to the output type';
+      case 'basic-filter':
+        return 'Continue the integration only if criteria you specify in simple input fields are met. Suitable for most' +
+          ' integrations.';
+      case 'advanced-filter':
+        return 'Continue the integration only if criteria you define in scripting language expressions are met.';
     }
   }
 

--- a/src/app/integrations/integrations.module.ts
+++ b/src/app/integrations/integrations.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { DynamicFormsCoreModule } from '@ng2-dynamic-forms/core';
 import { DynamicFormsBootstrapUIModule } from '@ng2-dynamic-forms/ui-bootstrap';
@@ -25,8 +24,8 @@ import { IntegrationsSaveOrAddStepComponent } from './edit-page/save-or-add-step
 import { IntegrationsStepSelectComponent } from './edit-page/step-select/step-select.component';
 import { IntegrationsStepConfigureComponent } from './edit-page/step-configure/step-configure.component';
 import { DataMapperHostComponent } from './edit-page/step-configure/data-mapper-host.component';
+import { BasicFilterComponent } from './edit-page/step-configure/filter-steps/basic-filter.component';
 import { ListActionsComponent } from './edit-page/list-actions/list-actions.component';
-
 import { IntegrationsListPage } from './list-page/list-page.component';
 import { IntegrationsListToolbarComponent } from './list-toolbar/list-toolbar.component';
 import { IntegrationsFilterPipe } from './integrations-filter.pipe';
@@ -94,6 +93,7 @@ const routes: Routes = [
   ],
   declarations: [
     DataMapperHostComponent,
+    BasicFilterComponent,
     IntegrationsConfigureActionComponent,
     IntegrationsEditPage,
     IntegrationBasicsComponent,
@@ -112,6 +112,7 @@ const routes: Routes = [
     FlowViewStepComponent,
     ListActionsComponent,
   ],
-  providers: [CurrentFlow],
+  providers: [ CurrentFlow ],
 })
-export class IntegrationsModule {}
+export class IntegrationsModule {
+}

--- a/src/app/store/step/step.store.ts
+++ b/src/app/store/step/step.store.ts
@@ -47,15 +47,14 @@ export class StepStore {
       id: undefined,
       connection: undefined,
       action: undefined,
-      name: 'Filter',
-      description: 'Filter incoming data based on a set of criteria',
-      stepKind: 'filter',
+      name: 'Basic Filter',
+      description: 'Continue the integration only if criteria you specify in simple input fields are met. Suitable for' +
+      ' most integrations.',
+      stepKind: 'basic-filter',
       properties: {
         filter: {
-          type: 'textarea',
-          displayName: 'Only continue if',
+          displayName: 'Only continue if incoming data match all of the following',
           required: true,
-          rows: 10,
         },
       },
       configuredProperties: undefined,


### PR DESCRIPTION
## Overview
Initial run-through of the basic filter implementation for integrations.

## Changes
- Add basic filter component, interface, model, styling, HTML.
- Update parent step-configure component and HTML to communicate with filter sub-component.
- Update `step.store.ts` to include filter in list of available steps when creating integrations.
- Update README with some commitizen tips.