### PR TITLE
fix(integrations): Add more restrictions for showing the tooltip

### DIFF
--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.ts
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.ts
@@ -42,7 +42,12 @@ export class FlowViewStepComponent extends ChildAwarePage {
   }
 
   showTooltip() {
-    if (this.step.stepKind === 'endpoint') {
+    if (
+      this.step.stepKind &&
+      this.step.stepKind === 'endpoint' &&
+      this.step.connection &&
+      this.step.connection.name
+    ) {
       this.pop.show();
     }
   }


### PR DESCRIPTION
Tooltip over the icon area should only show up for connections and only if there's a connection name
set

relates to #690