### PR TITLE
feat(Connections): Confirm before leaving 'new connection' pages

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { SyndesisCommonModule } from './common/common.module';
 import { AppComponent } from './app.component';
 import { ConfigService } from './config.service';
 import { UserService } from './common/user.service';
+import { CanDeactivateGuard } from './common/can-deactivate-guard.service';
 import { log } from './logging';
 
 import { DataMapperModule } from 'syndesis.data.mapper';
@@ -230,6 +231,7 @@ export function restangularProviderConfigurer(
     ConfigService,
     OAuthService,
     UserService,
+    CanDeactivateGuard,
   ],
   bootstrap: [AppComponent],
 })

--- a/src/app/common/can-deactivate-guard.service.ts
+++ b/src/app/common/can-deactivate-guard.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { CanDeactivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+
+/**
+ * @see https://angular.io/guide/router#candeactivate-handling-unsaved-changes
+ */
+export interface CanComponentDeactivate {
+  canDeactivate: (nextState: RouterStateSnapshot) => Observable<boolean> | Promise<boolean> | boolean;
+}
+
+@Injectable()
+export class CanDeactivateGuard implements CanDeactivate<CanComponentDeactivate> {
+
+  canDeactivate(component: CanComponentDeactivate, currentRoute: ActivatedRouteSnapshot,
+      currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) {
+    return component.canDeactivate ? component.canDeactivate(nextState) : true;
+  }
+
+}

--- a/src/app/connections/connections-routes.module.ts
+++ b/src/app/connections/connections-routes.module.ts
@@ -8,6 +8,8 @@ import { ConnectionsCreatePage } from './create-page/create-page.component';
 import { ConnectionsConnectionBasicsComponent } from './create-page/connection-basics/connection-basics.component';
 import { ConnectionsConfigureFieldsComponent } from './create-page/configure-fields/configure-fields.component';
 import { ConnectionsReviewComponent } from './create-page/review/review.component';
+import { ConnectionsCancelComponent } from './create-page/cancel.component';
+import { CanDeactivateGuard } from '../common/can-deactivate-guard.service';
 
 const routes: Routes = [
   { path: '', component: ConnectionsListPage, pathMatch: 'full' },
@@ -18,12 +20,19 @@ const routes: Routes = [
       {
         path: 'connection-basics',
         component: ConnectionsConnectionBasicsComponent,
+        canDeactivate: [CanDeactivateGuard],
       },
       {
         path: 'configure-fields',
         component: ConnectionsConfigureFieldsComponent,
+        canDeactivate: [CanDeactivateGuard],
       },
-      { path: 'review', component: ConnectionsReviewComponent },
+      {
+        path: 'review',
+        component: ConnectionsReviewComponent,
+        canDeactivate: [CanDeactivateGuard],
+      },
+      { path: 'cancel', component: ConnectionsCancelComponent},
       { path: '**', redirectTo: 'connection-basics', pathMatch: 'full' },
     ],
   },

--- a/src/app/connections/connections.module.ts
+++ b/src/app/connections/connections.module.ts
@@ -14,6 +14,7 @@ import { ConnectionsCreatePage } from './create-page/create-page.component';
 import { ConnectionsConnectionBasicsComponent } from './create-page/connection-basics/connection-basics.component';
 import { ConnectionsConfigureFieldsComponent } from './create-page/configure-fields/configure-fields.component';
 import { ConnectionsReviewComponent } from './create-page/review/review.component';
+import { ConnectionsCancelComponent } from './create-page/cancel.component';
 import { ConnectionsListPage } from './list-page/list-page.component';
 import { ConnectionsListToolbarComponent } from './list-toolbar/list-toolbar.component';
 import { ConnectionsListComponent } from './list/list.component';
@@ -41,6 +42,7 @@ import { CurrentConnectionService } from './create-page/current-connection';
     ConnectionsConnectionBasicsComponent,
     ConnectionsConfigureFieldsComponent,
     ConnectionsReviewComponent,
+    ConnectionsCancelComponent,
     ConnectionsListPage,
     ConnectionsListToolbarComponent,
     ConnectionsListComponent,

--- a/src/app/connections/create-page/cancel.component.ts
+++ b/src/app/connections/create-page/cancel.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
+
+@Component({
+  selector: 'syndesis-connections-cancel',
+  template: '',
+})
+export class ConnectionsCancelComponent implements OnInit {
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {}
+
+  ngOnInit() {
+    this.router.navigate(['../..'], { relativeTo: this.route });
+  }
+
+}

--- a/src/app/connections/create-page/configure-fields/configure-fields.component.ts
+++ b/src/app/connections/create-page/configure-fields/configure-fields.component.ts
@@ -1,16 +1,16 @@
 import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
 
 import { CurrentConnectionService } from '../current-connection';
 import { Connection } from '../../../model';
-
 import { log } from '../../../logging';
+import { CanComponentDeactivate } from '../../../common/can-deactivate-guard.service';
 
 @Component({
   selector: 'syndesis-connections-configure-fields',
   templateUrl: 'configure-fields.component.html',
 })
-export class ConnectionsConfigureFieldsComponent implements OnInit {
+export class ConnectionsConfigureFieldsComponent implements OnInit, CanComponentDeactivate {
   constructor(
     private current: CurrentConnectionService,
     private route: ActivatedRoute,
@@ -40,5 +40,12 @@ export class ConnectionsConfigureFieldsComponent implements OnInit {
     log.infoc(() => 'Credentials: ' + JSON.stringify(this.current.credentials));
     log.infoc(() => 'hasCredentials: ' + this.current.hasCredentials());
     */
+  }
+
+  canDeactivate(nextState: RouterStateSnapshot) {
+    return nextState.url === '/connections/create/cancel' ||
+           nextState.url === '/connections/create/connection-basics' ||
+           nextState.url === '/connections/create/review' ||
+           window.confirm('Discard changes?');
   }
 }

--- a/src/app/connections/create-page/connection-basics/connection-basics.component.ts
+++ b/src/app/connections/create-page/connection-basics/connection-basics.component.ts
@@ -1,17 +1,19 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Params, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
 
 import {
   CurrentConnectionService,
   ConnectionEvent,
 } from '../current-connection';
 import { Connection } from '../../../model';
+import { CanComponentDeactivate } from '../../../common/can-deactivate-guard.service';
 
 @Component({
   selector: 'syndesis-connections-connection-basics',
   templateUrl: 'connection-basics.component.html',
 })
-export class ConnectionsConnectionBasicsComponent implements OnInit {
+export class ConnectionsConnectionBasicsComponent implements OnInit, CanComponentDeactivate {
+
   constructor(
     private current: CurrentConnectionService,
     public route: ActivatedRoute,
@@ -39,5 +41,11 @@ export class ConnectionsConnectionBasicsComponent implements OnInit {
         subscription.unsubscribe();
       },
     );
+  }
+
+  canDeactivate(nextState: RouterStateSnapshot) {
+    return nextState.url === '/connections/create/cancel' ||
+           nextState.url === '/connections/create/configure-fields' ||
+           window.confirm('Discard changes?');
   }
 }

--- a/src/app/connections/create-page/create-page.component.ts
+++ b/src/app/connections/create-page/create-page.component.ts
@@ -5,6 +5,7 @@ import { NavigationService } from '../../common/navigation.service';
 import { CurrentConnectionService } from './current-connection';
 import { Connection, TypeFactory } from '../../model';
 import { log, getCategory } from '../../logging';
+import { CanComponentDeactivate } from '../../common/can-deactivate-guard.service';
 
 const category = getCategory('Connections');
 
@@ -69,7 +70,7 @@ export class ConnectionsCreatePage implements OnInit, OnDestroy {
   }
 
   cancel() {
-    this.router.navigate(['..'], { relativeTo: this.route });
+    this.router.navigate(['cancel'], { relativeTo: this.route });
   }
 
   goBack() {

--- a/src/app/connections/create-page/review/review.component.ts
+++ b/src/app/connections/create-page/review/review.component.ts
@@ -1,13 +1,18 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
 
-import { CurrentConnectionService } from '../current-connection';
+import { CurrentConnectionService, ConnectionEvent } from '../current-connection';
 import { Connection } from '../../../model';
+import { CanComponentDeactivate } from '../../../common/can-deactivate-guard.service';
 
 @Component({
   selector: 'syndesis-connections-review',
   templateUrl: 'review.component.html',
 })
-export class ConnectionsReviewComponent implements OnInit {
+export class ConnectionsReviewComponent implements OnInit, CanComponentDeactivate {
+
+  private saved = false;
+
   constructor(private current: CurrentConnectionService) {}
 
   get connection(): Connection {
@@ -18,5 +23,19 @@ export class ConnectionsReviewComponent implements OnInit {
     this.current.connection = connection;
   }
 
-  ngOnInit() {}
+  ngOnInit() {
+    const subscription = this.current.events.subscribe((event: ConnectionEvent) => {
+      if (event.kind === 'connection-save-connection') {
+        this.saved = true;
+        subscription.unsubscribe();
+      }
+    });
+  }
+
+  canDeactivate(nextState: RouterStateSnapshot) {
+    return this.saved ||
+           nextState.url === '/connections/create/cancel' ||
+           nextState.url === '/connections/create/configure-fields' ||
+           window.confirm('Discard changes?');
+  }
 }


### PR DESCRIPTION
I'm using window.confirm to show a confirmation dialog to the user. To show a modal, we need to implement a modal service that shows the modal dialog and returns a promise with the result (yes/no).