### PR TITLE
feat(integrations): hide data mapper if the integration is missing types

### DIFF
--- a/src/app/integrations/edit-page/step-select/step-select.component.html
+++ b/src/app/integrations/edit-page/step-select/step-select.component.html
@@ -32,13 +32,9 @@
     </div>
     <p>Choose a step from below</p>
     <div class="list-group list-view-pf list-view-pf-view">
-<<<<<<< HEAD
-      <div class="step list-group-item" title="{{step.name}}"
-           *ngFor="let step of steps"
-=======
-      <div class="list-group-item"
+      <div class="step list-group-item"
+           title="{{step.name}}"
            *ngFor="let step of steps | stepVisible:{position: position}"
->>>>>>> feat(integrations): hide data mapper if the integration is missing types
            (click)="onSelect(step)"
            [class.active]="isSelected(step)">
         <div class="list-view-pf-main-info">

--- a/src/app/integrations/edit-page/step-select/step-select.component.html
+++ b/src/app/integrations/edit-page/step-select/step-select.component.html
@@ -32,8 +32,13 @@
     </div>
     <p>Choose a step from below</p>
     <div class="list-group list-view-pf list-view-pf-view">
+<<<<<<< HEAD
       <div class="step list-group-item" title="{{step.name}}"
            *ngFor="let step of steps"
+=======
+      <div class="list-group-item"
+           *ngFor="let step of steps | stepVisible:{position: position}"
+>>>>>>> feat(integrations): hide data mapper if the integration is missing types
            (click)="onSelect(step)"
            [class.active]="isSelected(step)">
         <div class="list-view-pf-main-info">

--- a/src/app/integrations/edit-page/step-select/step-select.component.ts
+++ b/src/app/integrations/edit-page/step-select/step-select.component.ts
@@ -8,6 +8,7 @@ import { FlowPage } from '../flow-page';
 import { Step, Steps, TypeFactory } from '../../../model';
 import { log, getCategory } from '../../../logging';
 
+
 @Component({
   selector: 'syndesis-integrations-step-select',
   templateUrl: './step-select.component.html',
@@ -63,8 +64,10 @@ export class IntegrationsStepSelectComponent extends FlowPage
       case 'mapper':
         return 'Map fields from the input type to the output type';
       case 'basic-filter':
-        return 'Continue the integration only if criteria you specify in simple input fields are met. Suitable for most' +
-          ' integrations.';
+        return (
+          'Continue the integration only if criteria you specify in simple input fields are met. Suitable for most' +
+          ' integrations.'
+        );
       case 'advanced-filter':
         return 'Continue the integration only if criteria you define in scripting language expressions are met.';
     }

--- a/src/app/integrations/edit-page/step-select/step-visible.pipe.ts
+++ b/src/app/integrations/edit-page/step-select/step-visible.pipe.ts
@@ -1,0 +1,29 @@
+import { Component, Pipe } from '@angular/core';
+import { StepStore, StepKind, StepKinds } from '../../../store/step/step.store';
+import { CurrentFlow } from '../current-flow.service';
+import { Step, Steps, TypeFactory } from '../../../model';
+
+export class StepVisibleConfig {
+  position: number;
+}
+
+@Pipe({
+  name: 'stepVisible',
+  pure: false,
+})
+export class StepVisiblePipe {
+  constructor(
+    private currentFlow: CurrentFlow,
+  ) {}
+  transform(objects: Array<StepKind>, config: StepVisibleConfig) {
+    const position = config.position;
+    const previous = this.currentFlow.getPreviousSteps(config.position);
+    const subsequent = this.currentFlow.getSubsequentSteps(config.position);
+    return objects.filter((s: StepKind) => {
+      if (s.visible && typeof s.visible === 'function') {
+        return s.visible(position, previous, subsequent);
+      }
+      return true;
+    });
+  }
+}

--- a/src/app/integrations/integrations.module.ts
+++ b/src/app/integrations/integrations.module.ts
@@ -21,6 +21,7 @@ import { IntegrationsConfigureActionComponent } from './edit-page/action-configu
 import { IntegrationsSelectActionComponent } from './edit-page/action-select/action-select.component';
 import { IntegrationsSaveOrAddStepComponent } from './edit-page/save-or-add-step/save-or-add-step.component';
 import { IntegrationsStepSelectComponent } from './edit-page/step-select/step-select.component';
+import { StepVisiblePipe } from './edit-page/step-select/step-visible.pipe';
 import { IntegrationsStepConfigureComponent } from './edit-page/step-configure/step-configure.component';
 import { DataMapperHostComponent } from './edit-page/step-configure/data-mapper/data-mapper-host.component';
 import { BasicFilterComponent } from './edit-page/step-configure/filter-steps/basic-filter.component';
@@ -109,6 +110,7 @@ const routes: Routes = [
     FlowViewComponent,
     FlowViewStepComponent,
     ListActionsComponent,
+    StepVisiblePipe,
   ],
   providers: [ CurrentFlow ],
 })


### PR DESCRIPTION
If the integration has a start or end action that doesn't have a data shape, prevent the data mapper
from being selected.

fixes #562