### PR TITLE
feat(integrations): Tighten up editor navigation

### DIFF
--- a/src/app/integrations/edit-page/current-flow.service.ts
+++ b/src/app/integrations/edit-page/current-flow.service.ts
@@ -214,6 +214,7 @@ export class CurrentFlow {
             position === this.getLastPosition()
           ) {
             this.steps[position] = TypeFactory.createStep();
+            this.steps[position].stepKind = 'endpoint';
           } else {
             this.steps.splice(position, 1);
           }

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.html
@@ -63,26 +63,22 @@
   </div>
 
 
-  <!-- Progress Menu -->
-
+  <!-- Step Item Wrapper -->
   <div class="col-md-9 menu"
        *ngIf="currentStepKind !== 'mapper'"
        [ngSwitch]="step.stepKind">
 
-    <!-- Endpoint Steps -->
-
+    <!-- Connection Steps -->
     <div *ngSwitchCase="'endpoint'"
          [class]="getParentActiveClass() + ' step-container'">
 
       <!-- Delete Icon -->
-
       <i *ngIf="showDelete()"
          class="delete-icon fa fa-lg fa-trash"
          (click)="deletePrompt()"></i>
 
 
-      <!-- Parent Step -->
-
+      <!-- Connection Title -->
       <span [class]="getParentClass()"
             (click)="goto('action-configure')">
         <i *ngIf="!isCollapsed()" class="fa fa-chevron-down"></i>
@@ -90,8 +86,7 @@
         {{ getStepText() }}
       </span>
 
-      <!-- Sub Steps -->
-
+      <!-- Connection Sub Pages -->
       <ul [collapse]="isCollapsed()"
           class="sub-steps">
         <li *ngIf="!step.connection"
@@ -119,19 +114,16 @@
     </div>
 
     <!-- Default Steps -->
-
     <div *ngSwitchDefault
          [class]="getParentActiveClass() + ' step-container'">
 
       <!-- Delete Icon -->
-
       <i *ngIf="showDelete()"
          class="delete-icon fa fa-lg fa-trash"
          [class.add-step-or-connection]="step.stepKind !== 'endpoint'"
          (click)="deletePrompt()"></i>
 
-      <!-- Parent Step Heading -->
-
+      <!-- Step Heading -->
       <span [class]="getParentClass()"
             (click)="goto('step-configure')">
         <i *ngIf="!isCollapsed()" class="fa fa-chevron-down"></i>
@@ -139,8 +131,7 @@
         {{ getStepText() | titleize:{separator: '-'} | capitalize}}
       </span>
 
-      <!-- Sub Steps -->
-
+      <!-- Step Sub Pages -->
       <ul [collapse]="isCollapsed()"
           class="sub-steps">
         <li *ngIf="!step.stepKind"

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.scss
@@ -147,6 +147,11 @@
         //background-color: #E7E7E7;
         background-color: $pf-black-300;
         cursor: pointer;
+
+        &.disabled {
+          cursor: default;
+        }
+
         display: inline;
         padding: 8px 100% 8px 8px;
         text-transform: uppercase;


### PR DESCRIPTION
Ensures the user has to complete a flow of pages for a connection or step before being able to click
elsewhere in the integration.  Also hides the trash icons for steps and connections unles s the user
is on the save or add step page.

fixes #696, fixes #723