### PR TITLE
fix(integrations): Basic filter fixes

### DIFF
--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.ts
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.ts
@@ -55,7 +55,11 @@ export class BasicFilterComponent implements OnChanges {
               private formService: DynamicFormService) {
   }
 
-  ngOnChanges() {
+  ngOnChanges(changes: any) {
+    if (!('position' in changes)) {
+      return;
+    }
+
     this.basicFilterModel = createBasicFilterModel(this.configuredProperties);
 
     this.integrationSupport.getFilterOptions(this.currentFlow.getIntegrationClone()).toPromise().then((resp: any) => {

--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.model.ts
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.model.ts
@@ -106,16 +106,22 @@ export function createBasicFilterModel(configuredProperties: BasicFilter) {
         },
       ),
     ];
-  };
+  }
   let groups = undefined;
   let rules = undefined;
   // build up the form array from the incoming values (if any)
-  if (configuredProperties && configuredProperties.rules && configuredProperties.rules.length) {
+  if (configuredProperties && configuredProperties.rules) {
     // TODO hackity hack
-    rules = JSON.parse(<any>configuredProperties.rules);
+    if (typeof configuredProperties.rules === 'string') {
+      rules = JSON.parse(<any>configuredProperties.rules);
+    } else {
+      rules = configuredProperties.rules;
+    }
     groups = [];
     for (const rule of rules) {
-      groups.push(new DynamicFormArrayGroupModel(undefined, groupFactory(rule)));
+      groups.push(
+        new DynamicFormArrayGroupModel(undefined, groupFactory(rule)),
+      );
     }
   }
   const answer = [
@@ -157,9 +163,7 @@ export function createBasicFilterModel(configuredProperties: BasicFilter) {
           {
             id: 'rulesFormArray',
             groups: groups,
-            initialCount: rules
-              ? rules.length
-              : 1,
+            initialCount: rules ? rules.length : 1,
             groupFactory: groupFactory,
           },
           {


### PR DESCRIPTION
validate before parsing JSON just to be on the safe side

@rhuss FYI, turns out there was another change that introduced the JSON parsing, this fix appears to load and save to the in-memory integration fine.