### PR TITLE
fix(connections): Guard against missing propert...

### DIFF
--- a/src/app/connections/view/view.component.ts
+++ b/src/app/connections/view/view.component.ts
@@ -183,7 +183,9 @@ export class ConnectionViewComponent implements OnInit, OnChanges, OnDestroy {
       const props = JSON.parse(JSON.stringify(connection.connector.properties));
       if (connection.configuredProperties) {
         Object.keys(connection.configuredProperties).forEach(key => {
-          props[key].value = connection.configuredProperties[key];
+          if (props[key]) {
+            props[key].value = connection.configuredProperties[key];
+          }
         });
       } else {
         connection.configuredProperties = {};


### PR DESCRIPTION
...ies definitions appearing in configured properties

For Salesforce OAuth dance sets the `instanceUrl` property which was not
declared in connector `properties` but was encountered in
`configuredProperties`.

Fixes #763