### PR TITLE
feat(development): Adds configuration for staging

### DIFF
--- a/src/config.json.staging
+++ b/src/config.json.staging
@@ -1,0 +1,37 @@
+{
+  "commment":"This config should for testing against a minishift using the syndesis-dev application templates.",
+  "apiBase": "https://syndesis-staging.b6ff.rh-idev.openshiftapps.com",
+  "apiEndpoint": "/api/v1",
+  "title": "Syndesis",
+  "datamapper": {
+    "baseJavaInspectionServiceUrl": "/v2/atlas/java/",
+    "baseXMLInspectionServiceUrl": "/v2/atlas/xml/",
+    "baseJSONInspectionServiceUrl": "/v2/atlas/json/",
+    "baseMappingServiceUrl": "/v2/atlas/",
+    "discardNonMockSources": false,
+    "addMockJSONMappings": false,
+    "addMockJavaSingleSource": false,
+    "addMockJavaSources": false,
+    "addMockXMLInstanceSources": false,
+    "addMockXMLSchemaSources": false,
+    "addMockJSONSources": false,
+    "addMockJavaTarget": false,
+    "addMockXMLInstanceTarget": false,
+    "addMockXMLSchemaTarget": false,
+    "addMockJSONTarget": false,
+    "debugDocumentServiceCalls": false,
+    "debugMappingServiceCalls": false,
+    "debugClassPathServiceCalls": false,
+    "debugValidationServiceCalls": false,
+    "debugFieldActionServiceCalls": false,
+    "debugDocumentParsing": false
+  },
+  "oauth": {
+    "clientId": "syndesis-ui",
+    "scopes": ["openid"],
+    "oidc": true,
+    "hybrid": true,
+    "issuer": "/auth/realms/syndesis",
+    "auto-link-github": true
+  }
+}


### PR DESCRIPTION
Adds `config.json.staging` template configured for development against
the staging on Openshift Online.

Fixes #767