### PR TITLE
feat(integrations): send the output data shape instead of the whole i…

### DIFF
--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.ts
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.ts
@@ -98,9 +98,13 @@ export class BasicFilterComponent implements OnChanges {
       self.detector.detectChanges();
     }
 
+    // Get the output data shape from the first previous connection
+    const prevConnection = this.currentFlow.getPreviousConnection(this.position);
+    const dataShape = prevConnection ? prevConnection.action.outputDataShape : {};
+
     // Fetch our form data
     this.integrationSupport
-      .getFilterOptions(this.currentFlow.getIntegrationClone())
+      .getFilterOptions(dataShape)
       .toPromise()
       .then((resp: any) => {
         const body = JSON.parse(resp['_body']);

--- a/src/app/store/integration-support.service.ts
+++ b/src/app/store/integration-support.service.ts
@@ -19,13 +19,13 @@ export class IntegrationSupportService {
     this.filterService = restangular.service('integrations');
   }
 
-  getFilterOptions(integration: Integration): Observable<any> {
+  getFilterOptions(dataShape: any): Observable<any> {
     const url = this.filterService.one('filters').one('options').getRestangularUrl();
     const headers = new Headers({
       Authorization: 'Bearer ' + this.oauth.getAccessToken(),
     });
     const options = new RequestOptions({ headers: headers });
-    return this.http.post(url, integration, options);
+    return this.http.post(url, dataShape, options);
   }
 
   requestPom(integration: Integration) {


### PR DESCRIPTION
…ntegration

fixes #855 

@rhuss FYI the change doesn't break the view other than the typeahead, but now you can expect to get an object like:
 
```
{
  "kind": "java",
  "type": "twitter4j.Status"
}

```

Instead of the whole integration.