### PR TITLE
fix(datamapper): src/config.json is ignored for datamapper URL

### DIFF
--- a/src/app/integrations/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
+++ b/src/app/integrations/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
@@ -57,7 +57,6 @@ const MAPPING_KEY = 'atlasmapping';
   ],
   providers: [
     InitializationService,
-    ConfigService,
     MappingManagementService,
     ErrorHandlerService,
     DocumentManagementService,


### PR DESCRIPTION
Fixes #860

Problem was that the ConfigService instance passed in as a constructor arg is not populated with src/config.json. Once remove this line the shared instance populated with config.json is properly passed in and datamapper url respects them.