### PR TITLE
fix(metadata): pass dynamic input/output shapes...

### DIFF
--- a/src/app/integrations/edit-page/action-configure/action-configure.component.ts
+++ b/src/app/integrations/edit-page/action-configure/action-configure.component.ts
@@ -133,6 +133,8 @@ export class IntegrationsConfigureActionComponent extends FlowPage
           ? JSON.parse(response['_body'])
           : undefined;
         this.initForm(position, page, definition);
+        this.step.action.inputDataShape = definition.inputDataShape;
+        this.step.action.outputDataShape = definition.outputDataShape;
       })
       .catch(response => {
         log.debug('Error response: ' + JSON.stringify(response, undefined, 2));


### PR DESCRIPTION
... to the action

When the dynamic metadata is fetched it will hold enriched input/output
data shapes and needs to be updated on the underlying action. Otherwise
come mapping time we do not have the shape available to do the mapping.

Fixes #926