### PR TITLE
chore: Send JSON schema to mapper

### DIFF
--- a/src/app/integrations/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
+++ b/src/app/integrations/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
@@ -160,7 +160,7 @@ export class DataMapperHostComponent extends FlowPage
         this.cfg.addJavaDocument(type, isSource);
         break;
       case 'json':
-        this.cfg.addJSONDocument(type, documentContents, isSource);
+        this.cfg.addJSONDocument(type, dataShape.specification, isSource);
         break;
       case 'xml-instance':
         this.cfg.addXMLInstanceDocument(type, documentContents, isSource);


### PR DESCRIPTION
For datashapes with kind=json it is expected that the `specification`
field contains JSON schema as string. This provides the datamapper with
the value therein.

Fixes #947