### PR TITLE
feat(github-oauth): Setup with GitHub OAuth as part of FTUE

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,7 +6,7 @@
                                 [showClose]="showClose">
   </pfng-toast-notification-list>
 
-  <header *ngIf="loggedIn">
+  <header *ngIf="loggedIn && !firstTime">
 
     <!-- Navbar: Logged Out -->
     <nav class="navbar navbar-fixed-top navbar-light loggedOut"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -41,7 +41,18 @@ export class AppComponent implements OnInit, AfterViewInit {
    */
   logoDarkBg = 'assets/images/syndesis-logo-svg-white.svg';
 
+  /**
+   * @type {boolean}
+   * Flag used to determine whether or not the user is logged in.
+   */
   loggedIn = false;
+
+
+  /**
+   * @type {boolean}
+   * Flag used to determine whether or not the user is a first time user.
+   */
+  firstTime = false;
 
   /**
    * @type {string}

--- a/src/app/approuting/approuting.module.ts
+++ b/src/app/approuting/approuting.module.ts
@@ -32,6 +32,12 @@ const routes: Routes = [
       '../settings/settings.module#SettingsModule',
     canActivate: [AuthGuard],
   },
+  {
+    path: 'setup',
+    loadChildren:
+      '../setup/setup.module#SetupModule',
+    canActivate: [AuthGuard],
+  },
 ];
 
 @NgModule({

--- a/src/app/setup/github-oauth.component.html
+++ b/src/app/setup/github-oauth.component.html
@@ -1,0 +1,60 @@
+<div class="row github-oauth">
+  <div class="col-md-12">
+    <h1>Getting Started in Syndesis</h1>
+    <p>Welcome to Syndesis! To get started you will need to register and authorize Syndesis on GitHub and select a
+      location for storing integrations.</p>
+
+    <div class="step-one">
+      <h2>Register Syndesis</h2>
+      <div>
+        <p>To start using Syndesis with GitHub, register Syndesis as an OAuth application in GitHub.</p>
+      </div>
+      <div>
+        <button class="btn btn-default">Register Syndesis on GitHub</button>&nbsp;<a>Learn how to register an OAuth app on
+        GitHub. <span class="pficon pficon-info"></span></a>
+      </div>
+    </div>
+
+    <div class="step-two">
+      <h2>GitHub Authorization</h2>
+      <div>
+        <p>The Client ID and Client Secret generated in the first step will be used here to grant authorization for
+          Syndesis to act on your behalf.</p>
+      </div>
+      <div class="pull-right">
+        <a>Learn how to get client ID and client secret on GitHub. <span class="pficon pficon-info"></span></a>
+      </div>
+      <div>
+        <form class="form-horizontal" role="form">
+          <div class="form-group">
+            <label for="ghClientId" class="col-sm-2 control-label">Client ID</label>
+            <div class="col-sm-10">
+              <input type="text" class="form-control" id="ghClientId">
+            </div>
+          </div>
+          <div class="form-group">
+            <label for="ghClientSecret" class="col-sm-2 control-label">Client Secret</label>
+            <div class="col-sm-10">
+              <input type="password" class="form-control" id="ghClientSecret">
+            </div>
+          </div>
+          <div class="form-group">
+            <div class="col-sm-offset-2 col-sm-10">
+              <button type="submit" class="btn btn-default">Connect GitHub</button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div class="step-three">
+      <h2>Configure Integration Location</h2>
+      <div>Specify where to store the integration.</div>
+      <div>
+        <p>Connected Account</p>
+        <p>No connected account</p>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/src/app/setup/github-oauth.component.scss
+++ b/src/app/setup/github-oauth.component.scss
@@ -1,0 +1,23 @@
+@import 'patternfly-sass/assets/stylesheets/patternfly/color-variables';
+
+.github-oauth {
+  height: 100%;
+
+  :host {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: visible;
+  }
+
+  ul {
+    flex: 0 0 auto;
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
+
+  .col-md-12 {
+    height: 100%;
+  }
+}

--- a/src/app/setup/github-oauth.component.ts
+++ b/src/app/setup/github-oauth.component.ts
@@ -1,0 +1,42 @@
+import { Component, OnInit, ViewChild, ChangeDetectorRef } from '@angular/core';
+
+/**
+ * The GitHub account model
+ */
+//import { GitHubAccount } from '../model';
+import { Observable } from 'rxjs/Observable';
+
+export interface OAuthAppListItem {
+  expanded: boolean;
+  //account: GitHubAccount;
+}
+
+@Component({
+  selector: 'syndesis-github-oauth',
+  templateUrl: 'github-oauth.component.html',
+  styleUrls: ['./github-oauth.component.scss'],
+})
+export class GitHubOAuthSetupComponent implements OnInit {
+
+  loading: Observable<boolean>;
+  isLoading = true;
+
+  constructor(public detector: ChangeDetectorRef) {}
+
+  /**
+   * Returns whether or not this item has stored credentials
+   */
+  isConfigured(item) {
+    const client = item.client || {};
+    return (
+      client.clientId &&
+      client.clientId !== '' &&
+      (client.clientSecret && client.clientSecret !== '')
+    );
+  }
+
+  /**
+   * View initialization
+    */
+  ngOnInit() {}
+}

--- a/src/app/setup/setup-root.component.ts
+++ b/src/app/setup/setup-root.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+@Component({
+  selector: 'syndesis-setup-root',
+  template: '<router-outlet></router-outlet>',
+})
+export class SetupRootComponent implements OnInit {
+  constructor(private route: ActivatedRoute, private router: Router) {}
+
+  ngOnInit() {}
+}

--- a/src/app/setup/setup.module.ts
+++ b/src/app/setup/setup.module.ts
@@ -1,0 +1,44 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
+import { DynamicFormsCoreModule } from '@ng2-dynamic-forms/core';
+import { SyndesisCommonModule } from '../common/common.module';
+
+import { SetupRootComponent } from './setup-root.component';
+import { GitHubOAuthSetupComponent } from './github-oauth.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: SetupRootComponent,
+    children: [
+      {
+        path: 'github-account',
+        component: GitHubOAuthSetupComponent,
+      },
+      {
+        path: '',
+        redirectTo: 'github-account',
+      },
+    ],
+  },
+];
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    DynamicFormsCoreModule,
+    RouterModule.forChild(routes),
+    SyndesisCommonModule,
+  ],
+  exports: [],
+  declarations: [
+    SetupRootComponent,
+    GitHubOAuthSetupComponent,
+  ],
+  providers: [],
+})
+export class SetupModule {}


### PR DESCRIPTION
Hey, it's a start. Need to add in plumbing, styling, logic, tests, docs, lots more. This just creates a new module and component, adds the route, HTML.

<img width="1201" alt="screenshot 2017-09-15 16 29 54" src="https://user-images.githubusercontent.com/3844502/30490849-29839354-9a33-11e7-8dd6-2b7998e21bde.png">

Outstanding:
- Programmatically collapse the sidebar and navbar.
- Alternatively, or in addition, add `ngIf` to check for flag set in the API that determines whether or not the user is a first time user to determine whether or not to show the sidebar and navbar.
- Add in plumbing with API once available.
- Check for client ID and secret to determine what to show the user (low priority, probably not for TP1 as we should just be worrying about users that have not connected their GH accounts).
- Styling and closer reflection of the designs provided by UXD.