### PR TITLE
feat(docs): Add link to external Fuse docs and icon

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -32,6 +32,7 @@
         </button>
 
         <!-- Logo -->
+
         <a [routerLink]=" ['/'] "
            class="navbar-brand">
            <!--
@@ -48,10 +49,33 @@
       </div>
 
       <!-- Top Navbar -->
+
       <nav>
         <ul class="nav navbar-nav navbar-right navbar-iconic">
 
-          <!-- User w/ no dropdown -->
+          <!-- Help Navbar -->
+
+          <li dropdown
+              class="dropdown help">
+            <a dropdownToggle
+               class="dropdown-toggle nav-item-iconic"
+               id="dropdownHelp"
+               aria-haspopup="true"
+               aria-expanded="true">
+              <span title="Help"
+                    class="fa pficon-help"></span>
+              <span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu"
+                aria-labelledby="horizontalDropdownMenu1">
+              <li><a href="https://access.redhat.com/documentation/en-us/red_hat_jboss_fuse/7.0-tp/html-single/fuse_ignite_sample_integration_tutorial/"
+                     rel="nofollow"
+                     target="_blank">Documentation</a></li>
+            </ul>
+          </li>
+
+          <!-- User w/ No Dropdown -->
+
           <li class="nav-item-iconic">
             <span title="Username"
                   class="fa pficon-user"></span>
@@ -59,7 +83,9 @@
           </li>
 
           <!-- User Dropdown -->
+
           <!--
+
           <li dropdown
               class="dropdown user">
             <a dropdownToggle

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -71,6 +71,10 @@
               <li><a href="https://access.redhat.com/documentation/en-us/red_hat_jboss_fuse/7.0-tp/html-single/fuse_ignite_sample_integration_tutorial/"
                      rel="nofollow"
                      target="_blank">Documentation</a></li>
+              <li><a href="mailto:fuse-ignite-tech-preview@redhat.com"
+                     rel="nofollow"
+                     target="_blank">Contact Us</a></li>
+              <li><a>About</a></li>
             </ul>
           </li>
 


### PR DESCRIPTION
Will add in the About link in the dropdown once we have the content for the modal. cc @dongniwang 

<img width="1120" alt="screenshot 2017-09-21 13 31 48" src="https://user-images.githubusercontent.com/3844502/30695784-542c563e-9ed1-11e7-9b7f-466bbaa0420b.png">
<img width="1119" alt="screenshot 2017-09-21 13 31 56" src="https://user-images.githubusercontent.com/3844502/30695786-5561be9a-9ed1-11e7-8e27-07ff3ac09ef9.png">
