### PR TITLE
chore: enable validations for SQL stored connector

### DIFF
--- a/src/app/connections/common/configuration/configuration.service.ts
+++ b/src/app/connections/common/configuration/configuration.service.ts
@@ -12,6 +12,7 @@ export class ConnectionConfigurationService {
     switch (id) {
       case 'salesforce':
       case 'twitter':
+      case 'sql-stored-connector':
         return true;
     }
     return false;


### PR DESCRIPTION
Adds `sql-stored-connector` to the list of connectors that we validate.