### PR TITLE
[WIP] feat(logout): Add logout support

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -81,14 +81,15 @@
 
           <!-- User w/ No Dropdown -->
 
+          <!--
           <li class="nav-item-iconic">
             <span title="Username"
                   class="fa pficon-user"></span>
             <span class="username">{{( user | async)?.name}}</span>
           </li>
+          -->
 
           <!-- User Dropdown -->
-          <!--
           <li dropdown
               class="dropdown user">
             <a dropdownToggle
@@ -105,6 +106,10 @@
                 class="dropdown-menu"
                 aria-labelledby="dropdownMenu2">
               <li>
+                <a (click)="logout()">Logout</a>
+              </li>
+              <!--
+              <li>
                 <a (click)="resetDB()">Reset DB</a>
               </li>
               <li>
@@ -113,9 +118,9 @@
               <li>
                 <a (click)="showImportDB()">Import DB</a>
               </li>
+              -->
             </ul>
           </li>
-        -->
         </ul>
       </nav>
     </nav>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,3 +1,5 @@
+@import 'patternfly-sass/assets/stylesheets/patternfly/color-variables';
+
 :host, .app, main {
   height: 100%;
 }
@@ -18,6 +20,12 @@ main {
         a:focus {
           outline: none;
           text-decoration: none;
+        }
+      }
+
+      .dropdown {
+        li {
+          cursor: pointer;
         }
       }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -149,7 +149,7 @@ export class AppComponent implements OnInit, AfterViewInit {
       showClose: true,
     });
     this.loggedIn =  false;
-    return this.userService.logout();
+    return this.oauthService.logOut();
   }
 
   /**

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,6 +13,7 @@ import {
   Notification,
   NotificationEvent,
   NotificationService,
+  NotificationType,
 } from 'patternfly-ng';
 
 import { TestSupportService } from './store/test-support.service';
@@ -138,6 +139,20 @@ export class AppComponent implements OnInit, AfterViewInit {
   }
 
   /**
+   * Function that calls UserService to log the user out.
+   */
+  logout() {
+    this.popNotification({
+      type: NotificationType.SUCCESS,
+      header: 'Logout Successful',
+      message: 'You\'ve successfully been logged out.',
+      showClose: true,
+    });
+    this.loggedIn =  false;
+    return this.userService.logout();
+  }
+
+  /**
    * Function that resets the database.
    */
   resetDB() {
@@ -194,6 +209,19 @@ export class AppComponent implements OnInit, AfterViewInit {
    */
   handleClose($event: NotificationEvent): void {
     this.notificationService.remove($event.notification);
+  }
+
+  //-----  Toast ------------------->>
+
+  popNotification(notification) {
+    this.notificationService.message(
+      notification.type,
+      notification.header,
+      notification.message,
+      false,
+      null,
+      [],
+    );
   }
 
   ngAfterViewInit() {

--- a/src/app/common/user.service.ts
+++ b/src/app/common/user.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { OAuthService } from 'angular-oauth2-oidc-hybrid';
 
 import { User } from '../model';
 
@@ -8,15 +7,8 @@ import { User } from '../model';
 export class UserService {
   private _user = new BehaviorSubject(<User>{});
 
-  constructor(private oauthService: OAuthService) {}
-
-
   get user() {
     return this._user.asObservable();
-  }
-
-  logout() {
-    return this.oauthService.logOut();
   }
 
   setUser(u: User) {

--- a/src/app/common/user.service.ts
+++ b/src/app/common/user.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { OAuthService } from 'angular-oauth2-oidc-hybrid';
 
 import { User } from '../model';
 
@@ -7,8 +8,15 @@ import { User } from '../model';
 export class UserService {
   private _user = new BehaviorSubject(<User>{});
 
+  constructor(private oauthService: OAuthService) {}
+
+
   get user() {
     return this._user.asObservable();
+  }
+
+  logout() {
+    return this.oauthService.logOut();
   }
 
   setUser(u: User) {


### PR DESCRIPTION
~WIP as this is an initial pass-thru. Adds 'logout' to dropdown, toast notification, calls oauthService's `logout` method, updates local component var to hide certain items. The oauthService `logout` method is not currently working properly, results in an invalid redirect URI error, which doesn't surprise me as I'm not sure how logout with angular-oauth2-oidc is going to work moving forward without GitHub auth. Some changes will likely need to be made there, or we need an easy way to access the user token easily to delete it.~

Changes:
- Add method to `userService` and call from the `AppComponent`.
- Remove reference to `oauthService`.
- Add Logout to dropdown menu.
- Use new logout endpoint to make direct HTTP call.
- Add toast notification to confirm success/failure of logout request.

cc @jimmidyson 

fix #1035 