### PR TITLE
refactor: make dynamic action properties with e...

### DIFF
--- a/src/app/common/forms.service.ts
+++ b/src/app/common/forms.service.ts
@@ -5,6 +5,7 @@ import {
   DynamicCheckboxModel,
   DynamicInputModel,
   DynamicTextAreaModel,
+  DynamicSelectModel,
 } from '@ng2-dynamic-forms/core';
 
 export interface ConfiguredConfigurationProperty extends ConfigurationProperty {
@@ -48,7 +49,7 @@ export class FormFactoryService {
         case 'hidden':
           break;
         default:
-          type = 'text';
+          type = value.enum ? 'select' : 'text';
           break;
       }
       // then use the appropriate ng2 dynamic forms constructor
@@ -91,6 +92,20 @@ export class FormFactoryService {
               control: 'col-sm-9',
               label: 'col-sm-3',
             },
+          },
+        );
+      } else if (type === 'select') {
+        formField = new DynamicSelectModel(
+          {
+            id: key,
+            multiple: false,
+            label: value.displayName || key,
+            value: (values[key] && values[key] in value.enum) ? values[key] : value.defaultValue || value.enum[0].value,
+            hint: value.description,
+            required: value.required,
+            validators: validators,
+            errorMessages: errorMessages,
+            options: value.enum,
           },
         );
       } else {

--- a/src/app/integrations/edit-page/action-configure/action-configure.component.ts
+++ b/src/app/integrations/edit-page/action-configure/action-configure.component.ts
@@ -106,7 +106,7 @@ export class IntegrationsConfigureActionComponent extends FlowPage
               const definition: any = response['_body'] ? JSON.parse(response['_body']) : undefined;
               for (const actionProperty of Object.keys(data)) {
                 if (data[actionProperty] == null) {
-                  this.step.configuredProperties[actionProperty] = definition.propertyDefinitionSteps.map(actionDefinitionStep => {
+                  this.step.configuredProperties[actionProperty] = definition.propertyDefinitionSteps.map((actionDefinitionStep) => {
                     return actionDefinitionStep.properties[actionProperty].defaultValue;
                   })[0];
                 }
@@ -152,7 +152,7 @@ export class IntegrationsConfigureActionComponent extends FlowPage
       .fetchMetadata(
         this.step.connection,
         this.step.action,
-        this.step.configuredProperties || {},
+        this.configuredPropertiesForMetadataCall(),
       )
       .toPromise()
       .then(response => {
@@ -230,6 +230,26 @@ export class IntegrationsConfigureActionComponent extends FlowPage
         this.detector.detectChanges();
       } catch (err) {}
     }, 30);
+  }
+
+  configuredPropertiesForMetadataCall() {
+    // fetches all properties from 0..this.position-1 steps, this way
+    // the backend does not fix a value and drills down into the detail
+    // of the selected value in this.position step, this allows enum
+    // values to be present in the same way as they are present when no
+    // value is selected by the user
+    const props = {};
+    const stepDefinitions = this.step.action.definition.propertyDefinitionSteps;
+    for (let p = 0; p < this.page; p++) {
+      for (const prop in stepDefinitions[p].properties) {
+        // we don't want null or undefined values here
+        if (this.step.configuredProperties[prop] != null) {
+          props[prop] = this.step.configuredProperties[prop];
+        }
+      }
+    }
+
+    return props;
   }
 
   ngOnInit() {


### PR DESCRIPTION
...num values render as HTML select

This detects that a metadata for a property contains `enum` and based on
that renders the property as a HTML select element. This would render
`displayValue` (or `label`) to the user instead of the `value` which
could/should hold the technical value, not meant to be shown to the
user.

The big issue is how the backend expects properties to be handed over at
a particular step in time. Now a property that is defined on the step
the user is in, and any subsequent step is not sent to the backend,
making it the same as if the user first arrived at the current step.

Fixes syndesisio/syndesis-verifier#45
Fixes syndesisio/syndesis-ui#1088
Fixes syndesisio/syndesis-ux#40
Fixes syndesisio/syndesis-rest#599