### PR TITLE
chore: uses patternfly combo box for select element

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -46,7 +46,8 @@
         "../node_modules/tether/dist/js/tether.js",
         "../node_modules/bootstrap/dist/js/bootstrap.js",
         "../node_modules/patternfly/dist/js/patternfly.js",
-        "../node_modules/chart.js/dist/Chart.js"
+        "../node_modules/chart.js/dist/Chart.js",
+        "../node_modules/patternfly-bootstrap-combobox/js/bootstrap-combobox.js"
       ],
       "environmentSource": "environments/environment.ts",
       "environments": {

--- a/src/app/common/ui-patternfly/syndesis-combobox.directive.ts
+++ b/src/app/common/ui-patternfly/syndesis-combobox.directive.ts
@@ -1,0 +1,13 @@
+import { Directive, ElementRef, Input, AfterViewChecked } from '@angular/core';
+
+@Directive({ selector: '[syndesisCombobox]' })
+export class SyndesisComboboxDirective implements AfterViewChecked {
+
+    constructor(private el: ElementRef) {
+      this.el = el;
+    }
+
+    ngAfterViewChecked() {
+       (<any>$(this.el.nativeElement)).combobox();
+    }
+}

--- a/src/app/common/ui-patternfly/syndesis-form-control.component.html
+++ b/src/app/common/ui-patternfly/syndesis-form-control.component.html
@@ -188,7 +188,7 @@
             </fieldset>
 
 
-            <select *ngSwitchCase="6"
+            <select *ngSwitchCase="6" syndesisCombobox
                     class="form-control"
                     [attr.tabindex]="model.tabIndex"
                     [dynamicId]="bindId && model.id"
@@ -202,8 +202,7 @@
 
                 <option *ngFor="let option of model.options$ | async"
                         [attr.name]="model.name"
-                        [ngValue]="option.value">{{option.label}}
-                </option>
+                        [ngValue]="option.value">{{option.label}}</option>
 
             </select>
 

--- a/src/app/common/ui-patternfly/ui-patternfly.module.ts
+++ b/src/app/common/ui-patternfly/ui-patternfly.module.ts
@@ -8,6 +8,7 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { ToolbarModule } from 'patternfly-ng';
 import { SyndesisFormComponent } from './syndesis-form-control.component';
 import { ListToolbarComponent } from './list-toolbar/list-toolbar.component';
+import { SyndesisComboboxDirective } from './syndesis-combobox.directive';
 
 @NgModule({
 
@@ -23,6 +24,7 @@ import { ListToolbarComponent } from './list-toolbar/list-toolbar.component';
     declarations: [
         SyndesisFormComponent,
         ListToolbarComponent,
+        SyndesisComboboxDirective,
     ],
     exports: [
         DynamicFormsCoreModule,


### PR DESCRIPTION
Adds a `syndesisCombobox` directive to apply combobox from Patternfly
to <select> elements and uses that for dynamic forms.