### PR TITLE
Updating the developer mode getting started instructions so that it works via redirecting the syndesis-ui service deployed in minishift.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,21 @@ git clone https://github.com/syndesisio/syndesis-ui.git
 # change directory to Syndesis
 cd syndesis-ui
 
-# Configure the UI
-sed "s/192.168.64.2/$(minishift ip)/" src/config.json.minishift > src/config.json
+# Configure the UI and Minishfit for dev mode.
+./scripts/minishift-setup.sh
 
 # install the dependencies
 yarn
 
 # start the server
-yarn start
+yarn start:minishift
 ```
 
-Go to [http://0.0.0.0:4200](http://0.0.0.0:4200) or [http://localhost:4200](http://localhost:4200) in your browser.
+Bring up the syndesis console in your browser.  You can start load it from the command line by running:
+
+```bash
+open http://$(oc get routes syndesis --template "{{.spec.host}}")
+```
 
 ## Table of Contents
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "karma-jasmine": "1.1.0",
     "karma-junit-reporter": "1.2.0",
     "karma-mocha-reporter": "2.2.3",
+    "my-local-ip": "^1.0.0",
     "ncp": "^2.0.0",
     "patternfly-sass": "3.23.2",
     "prettier": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "copy:assets": "yarn ncp node_modules/syndesis.data.mapper/src/assets/dm src/assets/dm",
     "start": "yarn ng serve -- --ssl true --ssl-key localhost.key --ssl-cert localhost.crt --proxy-config proxy.conf.js",
     "start:prod": "yarn ng serve -- --ssl true --ssl-key localhost.key --ssl-cert localhost.crt --proxy-config proxy.conf.js --aot --prod",
+    "start:minishift": "yarn ng serve -- --host 0.0.0.0 --disable-host-check",
     "lint": "yarn ng lint",
     "lint:fix": "yarn ng lint -- --fix",
     "test": "yarn ng test",

--- a/scripts/minishift-setup.sh
+++ b/scripts/minishift-setup.sh
@@ -8,7 +8,9 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"
 cd ..
 
 # Lets try to detect the local machine ip..
-LOCAL_IP="$(dig $(hostname) +short)"
+LOCAL_IP="$(./node_modules/.bin/my-local-ip)"
+echo "DETECTED Local IP is: ${LOCAL_IP}"
+
 LOCAL_IP="${1:-$LOCAL_IP}"
 
 sed "s/192.168.64.2/$(minishift ip)/" src/config.json.minishift > src/config.json

--- a/scripts/minishift-setup.sh
+++ b/scripts/minishift-setup.sh
@@ -1,0 +1,66 @@
+
+#!/bin/bash
+#
+#
+
+set -euo pipefail
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+cd ..
+
+# Lets try to detect the local machine ip..
+LOCAL_IP="$(nslookup $(hostname) | tail -n +4 | grep Address | cut -d " " -f 2)"
+LOCAL_IP="${1:-$LOCAL_IP}"
+
+sed "s/192.168.64.2/$(minishift ip)/" src/config.json.minishift > src/config.json
+oc replace --force -f - <<EOF
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "labels": {
+          "app": "syndesis",
+          "component": "syndesis-ui"
+        },
+        "name": "syndesis-ui"
+      },
+      "spec": {
+        "ports": [
+          {
+            "port": 80,
+            "protocol": "TCP",
+            "targetPort": 4200,
+            "name": "http"
+          }
+        ],
+        "selector": {}
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Endpoints",
+      "metadata": {
+        "name": "syndesis-ui"
+      },
+      "subsets": [
+        {
+          "addresses": [
+            {
+              "ip": "${LOCAL_IP}"
+            }
+          ],
+          "ports": [
+            {
+              "name": "http",
+              "port": 4200
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+EOF

--- a/scripts/minishift-setup.sh
+++ b/scripts/minishift-setup.sh
@@ -8,7 +8,7 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"
 cd ..
 
 # Lets try to detect the local machine ip..
-LOCAL_IP="$(nslookup $(hostname) | tail -n +4 | grep Address | cut -d " " -f 2)"
+LOCAL_IP="$(dig $(hostname) +short)"
 LOCAL_IP="${1:-$LOCAL_IP}"
 
 sed "s/192.168.64.2/$(minishift ip)/" src/config.json.minishift > src/config.json

--- a/yarn.lock
+++ b/yarn.lock
@@ -4732,6 +4732,10 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
+my-local-ip@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/my-local-ip/-/my-local-ip-1.0.0.tgz#37585555a4ff1985309edac7c2a045a466be6c32"
+
 nan@^2.3.0, nan@^2.3.2:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"


### PR DESCRIPTION
This allows you to run in dev mode even when your using an oauth-proxy in front of the UI service.