### PR TITLE
fix(integrations): Comment out the guided tour block for now in the integration editor

### DIFF
--- a/src/app/integrations/edit-page/edit-page.component.ts
+++ b/src/app/integrations/edit-page/edit-page.component.ts
@@ -203,7 +203,6 @@ export class IntegrationsEditPage extends ChildAwarePage
     this.routeSubscription = this.route.params
       .pluck<Params, string>('integrationId')
       .map((integrationId: string) => {
-        console.log('Integration id: ', integrationId);
         this.store.loadOrCreate(integrationId);
       })
       .subscribe();

--- a/src/app/integrations/edit-page/edit-page.component.ts
+++ b/src/app/integrations/edit-page/edit-page.component.ts
@@ -52,58 +52,6 @@ export class IntegrationsEditPage extends ChildAwarePage
         this.handleFlowEvent(event);
       },
     );
-
-    /**
-     * If guided tour state is set to be shown (i.e. true), then show it for this page, otherwise don't.
-     */
-    if (this.userService.getTourState() === true) {
-      this.tourService.initialize([ {
-          route: 'integrations/create/connection-select/0',
-          title: 'Available Connections',
-          content: 'After at least two connections are available, you can create an integration that uses the connections you choose.',
-          anchorId: 'integrations.connections',
-          placement: 'top',
-        }, {
-          route: 'integrations/create/connection-select/0',
-          title: 'Integration Panel',
-          content: 'As you create an integration, see its connections and steps in the order ' +
-          'in which they occur when the integration is running.',
-          anchorId: 'integrations.panel',
-          placement: 'right',
-        }, {
-          route: 'integrations/create/action-select/0',
-          title: 'Available Actions',
-          content: 'When an integration uses the selected connection it performs the action you select.',
-          anchorId: 'integrations.actions',
-          placement: 'top',
-        }, {
-          route: 'integrations/create/action-configure/0/0',
-          title: 'Done',
-          content: 'Clicking Done adds the finish connection to the integration. ' +
-          'You can then add one or more steps that operate on the data.',
-          anchorId: 'integrations.done',
-          placement: 'bottom',
-        }, {
-          route: 'integrations/create/save-or-add-step?validate=true',
-          title: 'Operate On Data',
-          content: 'Clicking the plus sign lets you add an operation that ' +
-          'the integration performs between the start and finish connections.',
-          anchorId: 'integrations.step',
-          placement: 'right',
-        }, {
-          route: 'integrations/create/integration-basics',
-          title: 'Publish',
-          content: 'Click Publish to start running the integration, which will take a moment or two. ' +
-          'Click Save as Draft to save the integration without deploying it.',
-          anchorId: 'integrations.publish',
-          placement: 'bottom',
-        } ],
-        {
-          route: '',
-        },
-      );
-      this.tourService.start();
-    }
   }
 
   getPageRow() {
@@ -178,29 +126,103 @@ export class IntegrationsEditPage extends ChildAwarePage
         // ignore;
       }
     });
-    this.routeSubscription = this.route.params
-      .pluck<Params, string>('integrationId')
-      .map((integrationId: string) => {
-        this.store.loadOrCreate(integrationId);
-      })
-      .subscribe();
     this.integrationSubscription = this.integration.subscribe(
       (i: Integration) => {
         if (i) {
           this.currentFlow.integration = i;
+          /**
+           * If guided tour state is set to be shown (i.e. true), then show it for this page, otherwise don't.
+           */
+          /*
+          if (this.userService.getTourState() === true) {
+            this.tourService.initialize(
+              [
+                {
+                  route: 'integrations/create/connection-select/0',
+                  title: 'Available Connections',
+                  content:
+                    'After at least two connections are available, you can create an integration that uses the connections you choose.',
+                  anchorId: 'integrations.connections',
+                  placement: 'top',
+                },
+                {
+                  route: 'integrations/create/connection-select/0',
+                  title: 'Integration Panel',
+                  content:
+                    'As you create an integration, see its connections and steps in the order ' +
+                    'in which they occur when the integration is running.',
+                  anchorId: 'integrations.panel',
+                  placement: 'right',
+                },
+                {
+                  route: 'integrations/create/action-select/0',
+                  title: 'Available Actions',
+                  content:
+                    'When an integration uses the selected connection it performs the action you select.',
+                  anchorId: 'integrations.actions',
+                  placement: 'top',
+                },
+                {
+                  route: 'integrations/create/action-configure/0/0',
+                  title: 'Done',
+                  content:
+                    'Clicking Done adds the finish connection to the integration. ' +
+                    'You can then add one or more steps that operate on the data.',
+                  anchorId: 'integrations.done',
+                  placement: 'bottom',
+                },
+                {
+                  route: 'integrations/create/save-or-add-step?validate=true',
+                  title: 'Operate On Data',
+                  content:
+                    'Clicking the plus sign lets you add an operation that ' +
+                    'the integration performs between the start and finish connections.',
+                  anchorId: 'integrations.step',
+                  placement: 'right',
+                },
+                {
+                  route: 'integrations/create/integration-basics',
+                  title: 'Publish',
+                  content:
+                    'Click Publish to start running the integration, which will take a moment or two. ' +
+                    'Click Save as Draft to save the integration without deploying it.',
+                  anchorId: 'integrations.publish',
+                  placement: 'bottom',
+                },
+              ],
+              {
+                route: '',
+              },
+            );
+            this.tourService.start();
+          }
+          */
         }
       },
     );
+    this.routeSubscription = this.route.params
+      .pluck<Params, string>('integrationId')
+      .map((integrationId: string) => {
+        console.log('Integration id: ', integrationId);
+        this.store.loadOrCreate(integrationId);
+      })
+      .subscribe();
     this.nav.hide();
   }
 
   ngOnDestroy() {
     this.nav.show();
-    this.integrationSubscription.unsubscribe();
-    this.routeSubscription.unsubscribe();
+    if (this.integrationSubscription) {
+      this.integrationSubscription.unsubscribe();
+    }
+    if (this.routeSubscription) {
+      this.routeSubscription.unsubscribe();
+    }
     if (this.flowSubscription) {
       this.flowSubscription.unsubscribe();
     }
-    this.routerEventsSubscription.unsubscribe();
+    if (this.routerEventsSubscription) {
+      this.routerEventsSubscription.unsubscribe();
+    }
   }
 }

--- a/src/app/integrations/edit-page/flow-view/flow-view.component.ts
+++ b/src/app/integrations/edit-page/flow-view/flow-view.component.ts
@@ -211,15 +211,21 @@ export class FlowViewComponent extends ChildAwarePage
   }
 
   ngOnInit() {
+    /*
     this.routeSubscription = this.router.events.subscribe(event => {
       try {
         this.detector.detectChanges();
       } catch (err) {}
     });
+    */
   }
 
   ngOnDestroy() {
-    this.routeSubscription.unsubscribe();
-    this.flowSubscription.unsubscribe();
+    if (this.routeSubscription) {
+      this.routeSubscription.unsubscribe();
+    }
+    if (this.flowSubscription) {
+      this.flowSubscription.unsubscribe();
+    }
   }
 }

--- a/src/app/integrations/edit-page/step-configure/step-configure.component.ts
+++ b/src/app/integrations/edit-page/step-configure/step-configure.component.ts
@@ -259,6 +259,8 @@ export class IntegrationsStepConfigureComponent extends FlowPage
 
   ngOnDestroy() {
     super.ngOnDestroy();
-    this.routeSubscription.unsubscribe();
+    if (this.routeSubscription) {
+      this.routeSubscription.unsubscribe();
+    }
   }
 }


### PR DESCRIPTION
@kahboom I'm thinking maybe it's worth waiting to intialize the tour until we've loaded the integration, I've moved that block of code where that happens, probably also should make it conditional, as the tour probably shouldn't be started if it's a previously loaded integration, i.e. it only has an ID if we're loading a previously created integration, if it's a new integration then there's no ID.

fixes #1194