### PR TITLE
Reformat using Prettier, comply with TSLint

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,6 +1,8 @@
 @import 'patternfly-sass/assets/stylesheets/patternfly/color-variables';
 
-:host, .app, main {
+:host,
+.app,
+main {
   height: 100%;
 }
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -22,7 +22,7 @@ describe('AppComponent', () => {
 
   beforeEach(() => {
     const configServiceStub = {
-      getSettings: (...params) => APP_NAME,
+      getSettings: (...params) => APP_NAME
     };
 
     TestBed.configureTestingModule({
@@ -35,7 +35,7 @@ describe('AppComponent', () => {
         CollapseModule.forRoot(),
         BsDropdownModule.forRoot(),
         NotificationModule,
-        TourNgxBootstrapModule.forRoot(),
+        TourNgxBootstrapModule.forRoot()
       ],
       providers: [
         ConfigService,
@@ -49,11 +49,11 @@ describe('AppComponent', () => {
           useFactory: (backend, options) => {
             return new Http(backend, options);
           },
-          deps: [MockBackend, RequestOptions],
+          deps: [MockBackend, RequestOptions]
         },
-        { provide: ConfigService, useValue: configServiceStub },
+        { provide: ConfigService, useValue: configServiceStub }
       ],
-      declarations: [AppComponent],
+      declarations: [AppComponent]
     });
     TestBed.compileComponents();
   });
@@ -64,7 +64,7 @@ describe('AppComponent', () => {
       const fixture = TestBed.createComponent(AppComponent);
       const app = fixture.debugElement.componentInstance;
       expect(app).toBeTruthy();
-    }),
+    })
   );
 
   it(
@@ -73,6 +73,6 @@ describe('AppComponent', () => {
       const fixture = TestBed.createComponent(AppComponent);
       const app = fixture.debugElement.componentInstance;
       expect(app.appName).toEqual(APP_NAME);
-    }),
+    })
   );
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,10 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, OnInit, Inject } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  Inject
+} from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Response } from '@angular/http';
 import { Meta, Title } from '@angular/platform-browser';
@@ -7,7 +13,7 @@ import { Restangular } from 'ngx-restangular';
 import {
   Notification,
   NotificationEvent,
-  NotificationService,
+  NotificationService
 } from 'patternfly-ng';
 import { Observable } from 'rxjs/Observable';
 import { ModalService } from './common/modal/modal.service';
@@ -22,9 +28,9 @@ import { TourService } from 'ngx-tour-ngx-bootstrap';
 @Component({
   selector: 'syndesis-root',
   templateUrl: './app.component.html',
-  styleUrls: [ './app.component.scss' ],
+  styleUrls: ['./app.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [ Restangular, TestSupportService ],
+  providers: [Restangular, TestSupportService]
 })
 export class AppComponent implements OnInit, AfterViewInit {
   // TODO icon?
@@ -79,17 +85,18 @@ export class AppComponent implements OnInit, AfterViewInit {
    */
   showClose: boolean;
 
-  constructor(private config: ConfigService,
-              private userService: UserService,
-              public testSupport: TestSupportService,
-              private notificationService: NotificationService,
-              private navigationService: NavigationService,
-              public tourService: TourService,
-              private modalService: ModalService,
-              private title: Title,
-              private meta: Meta,
-              @Inject(DOCUMENT) private document: any) {
-  }
+  constructor(
+    private config: ConfigService,
+    private userService: UserService,
+    public testSupport: TestSupportService,
+    private notificationService: NotificationService,
+    private navigationService: NavigationService,
+    public tourService: TourService,
+    private modalService: ModalService,
+    private title: Title,
+    private meta: Meta,
+    @Inject(DOCUMENT) private document: any
+  ) {}
 
   ngOnInit() {
     this.appName = this.config.getSettings('branding', 'appName', 'Syndesis');
@@ -100,42 +107,42 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.productBuild = this.config.getSettings(
       'branding',
       'productBuild',
-      false,
+      false
     );
     this.logoWhiteBg = this.config.getSettings(
       'branding',
       'logoWhiteBg',
-      'assets/images/syndesis-logo-svg-white.svg',
+      'assets/images/syndesis-logo-svg-white.svg'
     );
     this.logoDarkBg = this.config.getSettings(
       'branding',
       'logoDarkBg',
-      'assets/images/syndesis-logo-svg-white.svg',
+      'assets/images/syndesis-logo-svg-white.svg'
     );
     this.iconDarkBg = this.config.getSettings(
       'branding',
       'iconDarkBg',
-      'assets/images/glasses_logo_square.png',
+      'assets/images/glasses_logo_square.png'
     );
     this.iconWhiteBg = this.config.getSettings(
       'branding',
       'iconWhiteBg',
-      'assets/images/glasses_logo_square.png',
+      'assets/images/glasses_logo_square.png'
     );
     const favicon32 = this.config.getSettings(
       'branding',
       'favicon32',
-      '/favicon-32x32.png',
+      '/favicon-32x32.png'
     );
     const favicon16 = this.config.getSettings(
       'branding',
       'favicon16',
-      '/favicon-16x16.png',
+      '/favicon-16x16.png'
     );
     const touchIcon = this.config.getSettings(
       'branding',
       'touchIcon',
-      '/apple-touch-icon.png',
+      '/apple-touch-icon.png'
     );
 
     if (this.document && this.document.getElementById) {
@@ -196,8 +203,8 @@ export class AppComponent implements OnInit, AfterViewInit {
    */
   exportDB() {
     this.testSupport.snapshotDB().subscribe((value: Response) => {
-      const blob = new Blob([ value.text() ], {
-        type: 'text/plain;charset=utf-8',
+      const blob = new Blob([value.text()], {
+        type: 'text/plain;charset=utf-8'
       });
       saveAs(blob, 'syndesis-db-export.json');
     });
@@ -210,7 +217,7 @@ export class AppComponent implements OnInit, AfterViewInit {
     this.modalService.show('importDb').then(modal => {
       if (modal.result) {
         return this.testSupport
-          .restoreDB(modal[ 'json' ])
+          .restoreDB(modal['json'])
           .take(1)
           .toPromise()
           .then(_ => log.debugc(() => 'DB has been imported'));
@@ -222,9 +229,9 @@ export class AppComponent implements OnInit, AfterViewInit {
    * Function that imports a database.
    */
   importDB(event, modal) {
-    const file = event.srcElement.files[ 0 ];
+    const file = event.srcElement.files[0];
     const reader = new FileReader();
-    reader.onload = _ => (modal[ 'json' ] = JSON.parse(reader.result));
+    reader.onload = _ => (modal['json'] = JSON.parse(reader.result));
     reader.readAsText(file, 'text/plain;charset=utf-8');
   }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,9 @@
-import { APP_INITIALIZER, NgModule, NgZone, InjectionToken } from '@angular/core';
+import {
+  APP_INITIALIZER,
+  NgModule,
+  NgZone,
+  InjectionToken
+} from '@angular/core';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 import { BrowserModule } from '@angular/platform-browser';
@@ -12,7 +17,7 @@ import {
   PopoverModule,
   TabsModule,
   TooltipModule,
-  TypeaheadModule,
+  TypeaheadModule
 } from 'ngx-bootstrap';
 import { TagInputModule } from 'ngx-chips';
 import { Restangular, RestangularModule } from 'ngx-restangular';
@@ -28,9 +33,7 @@ import { UserService } from './common/user.service';
 import { ConfigService } from './config.service';
 import { StoreModule } from './store/store.module';
 
-export function appInitializer(
-  configService: ConfigService,
-) {
+export function appInitializer(configService: ConfigService) {
   return () => {
     return configService.load();
   };
@@ -38,7 +41,7 @@ export function appInitializer(
 
 export function restangularProviderConfigurer(
   restangularProvider: any,
-  config: ConfigService,
+  config: ConfigService
 ) {
   restangularProvider.setPlainByDefault(true);
   restangularProvider.setBaseUrl(config.getSettings().apiEndpoint);
@@ -60,14 +63,18 @@ export function restangularProviderConfigurer(
   });
 }
 
-export const RESTANGULAR_MAPPER = new InjectionToken<Restangular>('restangularMapper');
+export const RESTANGULAR_MAPPER = new InjectionToken<Restangular>(
+  'restangularMapper'
+);
 export function mapperRestangularProvider(
   restangular: Restangular,
-  config: ConfigService,
+  config: ConfigService
 ) {
   return restangular.withConfig(restangularConfigurer => {
     const mapperEndpoint = config.getSettings().mapperEndpoint;
-    restangularConfigurer.setBaseUrl(mapperEndpoint ? mapperEndpoint : '/mapper/v1');
+    restangularConfigurer.setBaseUrl(
+      mapperEndpoint ? mapperEndpoint : '/mapper/v1'
+    );
   });
 }
 
@@ -96,10 +103,7 @@ export function mapperRestangularProvider(
     ReactiveFormsModule,
     HttpModule,
     DynamicFormsCoreModule.forRoot(),
-    RestangularModule.forRoot(
-      [ConfigService],
-      restangularProviderConfigurer,
-    ),
+    RestangularModule.forRoot([ConfigService], restangularProviderConfigurer),
     TabsModule.forRoot(),
     TooltipModule.forRoot(),
     ModalModule.forRoot(),
@@ -114,24 +118,24 @@ export function mapperRestangularProvider(
     SyndesisCommonModule.forRoot(),
     DataMapperModule,
     NotificationModule,
-    TourNgxBootstrapModule.forRoot(),
+    TourNgxBootstrapModule.forRoot()
   ],
   providers: [
     {
       provide: APP_INITIALIZER,
       useFactory: appInitializer,
       deps: [ConfigService],
-      multi: true,
+      multi: true
     },
     {
       provide: RESTANGULAR_MAPPER,
       useFactory: mapperRestangularProvider,
-      deps: [Restangular, ConfigService],
+      deps: [Restangular, ConfigService]
     },
     ConfigService,
     UserService,
-    CanDeactivateGuard,
+    CanDeactivateGuard
   ],
-  bootstrap: [AppComponent],
+  bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/src/app/approuting.module.ts
+++ b/src/app/approuting.module.ts
@@ -5,32 +5,31 @@ const routes: Routes = [
   { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
   {
     path: 'dashboard',
-    loadChildren: './dashboard/dashboard.module#DashboardModule',
+    loadChildren: './dashboard/dashboard.module#DashboardModule'
   },
   {
     path: 'integrations',
-    loadChildren: './integrations/integrations.module#IntegrationsModule',
+    loadChildren: './integrations/integrations.module#IntegrationsModule'
   },
   {
     path: 'templates',
-    loadChildren: './templates/templates-routes.module#TemplateRoutesModule',
+    loadChildren: './templates/templates-routes.module#TemplateRoutesModule'
   },
   {
     path: 'connections',
     loadChildren:
-      './connections/connections-routes.module#ConnectionsRoutesModule',
+      './connections/connections-routes.module#ConnectionsRoutesModule'
   },
   {
     path: 'settings',
-    loadChildren:
-      './settings/settings.module#SettingsModule',
-  },
+    loadChildren: './settings/settings.module#SettingsModule'
+  }
 ];
 
 @NgModule({
   imports: [
-    RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules }),
+    RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules })
   ],
-  exports: [RouterModule],
+  exports: [RouterModule]
 })
 export class AppRoutingModule {}

--- a/src/app/common/can-deactivate-guard.service.ts
+++ b/src/app/common/can-deactivate-guard.service.ts
@@ -1,23 +1,29 @@
 import { Injectable } from '@angular/core';
-import { CanDeactivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import {
+  CanDeactivate,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot
+} from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 
 /**
  * @see https://angular.io/guide/router#candeactivate-handling-unsaved-changes
  */
 export interface CanComponentDeactivate {
-  canDeactivate: (nextState: RouterStateSnapshot) => Observable<boolean> | Promise<boolean> | boolean;
+  canDeactivate: (
+    nextState: RouterStateSnapshot
+  ) => Observable<boolean> | Promise<boolean> | boolean;
 }
 
 @Injectable()
-export class CanDeactivateGuard implements CanDeactivate<CanComponentDeactivate> {
-
+export class CanDeactivateGuard
+  implements CanDeactivate<CanComponentDeactivate> {
   canDeactivate(
     component: CanComponentDeactivate,
     currentRoute: ActivatedRouteSnapshot,
     currentState: RouterStateSnapshot,
-    nextState: RouterStateSnapshot) {
+    nextState: RouterStateSnapshot
+  ) {
     return component.canDeactivate ? component.canDeactivate(nextState) : true;
   }
-
 }

--- a/src/app/common/capitalize.pipe.ts
+++ b/src/app/common/capitalize.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: 'capitalize',
+  name: 'capitalize'
 })
 export class CapitalizePipe implements PipeTransform {
   transform(value: string) {

--- a/src/app/common/common.module.ts
+++ b/src/app/common/common.module.ts
@@ -29,7 +29,7 @@ import { TagInputModule } from 'ngx-chips';
     //HttpModule,
     FormsModule,
     CommonModule,
-    TagInputModule,
+    TagInputModule
   ],
   declarations: [
     DerpPipe,
@@ -44,7 +44,7 @@ import { TagInputModule } from 'ngx-chips';
     ModalComponent,
     EditableTagsComponent,
     EditableTextComponent,
-    EditableTextareaComponent,
+    EditableTextareaComponent
   ],
   exports: [
     DerpPipe,
@@ -59,11 +59,9 @@ import { TagInputModule } from 'ngx-chips';
     ModalComponent,
     EditableTagsComponent,
     EditableTextComponent,
-    EditableTextareaComponent,
+    EditableTextareaComponent
   ],
-  providers: [
-    FormFactoryService,
-  ],
+  providers: [FormFactoryService]
 })
 export class SyndesisCommonModule {
   static forRoot(): ModuleWithProviders {
@@ -75,8 +73,8 @@ export class SyndesisCommonModule {
         ConfigService,
         ModalService,
         NotificationService,
-        NavigationService,
-      ],
+        NavigationService
+      ]
     };
   }
 }

--- a/src/app/common/derp.pipe.ts
+++ b/src/app/common/derp.pipe.ts
@@ -17,7 +17,7 @@ of a larger data structure. Please read: https://github.com/angular/angular/issu
 */
 @Pipe({
   name: 'derp',
-  pure: false,
+  pure: false
 })
 export class DerpPipe implements PipeTransform {
   transform(value, args) {

--- a/src/app/common/editable/editable-tags.component.ts
+++ b/src/app/common/editable/editable-tags.component.ts
@@ -33,12 +33,10 @@ import { EditableComponent } from './editable.component';
       <button type="button" class="btn btn-primary" (click)="submit(tagInput.items)">Save</button>
       <button type="button" class="btn btn-default" (click)="cancel()">Cancel</button>
     </ng-container>
-  `,
+  `
 })
 export class EditableTagsComponent extends EditableComponent {
-
   constructor(detector: ChangeDetectorRef) {
     super(detector);
   }
-
 }

--- a/src/app/common/editable/editable-text.component.ts
+++ b/src/app/common/editable/editable-text.component.ts
@@ -24,18 +24,18 @@ import { EditableComponent } from './editable.component';
       <button type="button" class="btn btn-default" (click)="cancel()">Cancel</button>
     </ng-container>
   `,
-  styles: [`
+  styles: [
+    `
     .form-control {
       font-size: inherit;
       height: inherit;
       line-height: inherit;
     }
-  `],
+  `
+  ]
 })
 export class EditableTextComponent extends EditableComponent {
-
   constructor(detector: ChangeDetectorRef) {
     super(detector);
   }
-
 }

--- a/src/app/common/editable/editable-textarea.component.ts
+++ b/src/app/common/editable/editable-textarea.component.ts
@@ -23,12 +23,10 @@ import { EditableComponent } from './editable.component';
       <button type="button" class="btn btn-primary" (click)="submit(textareaInput.value.trim())">Save</button>
       <button type="button" class="btn btn-default" (click)="cancel()">Cancel</button>
     </ng-container>
-  `,
+  `
 })
 export class EditableTextareaComponent extends EditableComponent {
-
   constructor(detector: ChangeDetectorRef) {
     super(detector);
   }
-
 }

--- a/src/app/common/editable/editable.component.spec.ts
+++ b/src/app/common/editable/editable.component.spec.ts
@@ -2,7 +2,6 @@ import { ChangeDetectorRef } from '@angular/core';
 import { EditableComponent } from './editable.component';
 
 describe('EditableComponent', () => {
-
   class MyEditableComponent extends EditableComponent {
     constructor(changeDetectorRef: ChangeDetectorRef) {
       super(changeDetectorRef);
@@ -24,59 +23,53 @@ describe('EditableComponent', () => {
   describe('submit', () => {
     it('sets error message', done => {
       spyOn(component, 'validate').and.returnValue(Promise.resolve(ERROR));
-      component.submit(VALUE2)
-        .then(() => {
-          expect(component.errorMessage).toBe(ERROR);
-          done();
-        });
+      component.submit(VALUE2).then(() => {
+        expect(component.errorMessage).toBe(ERROR);
+        done();
+      });
     });
 
     it('saves value when valid', done => {
       spyOn(component, 'validate').and.returnValue(Promise.resolve(null));
       const spy = spyOn(component, 'save');
-      component.submit(VALUE2)
-        .then(() => {
-          expect(spy).toHaveBeenCalledWith(VALUE2);
-          done();
-        });
+      component.submit(VALUE2).then(() => {
+        expect(spy).toHaveBeenCalledWith(VALUE2);
+        done();
+      });
     });
 
     it('does not save value when invalid', done => {
       spyOn(component, 'validate').and.returnValue(Promise.resolve(ERROR));
       const spy = spyOn(component, 'save');
-      component.submit(VALUE2)
-        .then(() => {
-          expect(spy).not.toHaveBeenCalled();
-          done();
-        });
+      component.submit(VALUE2).then(() => {
+        expect(spy).not.toHaveBeenCalled();
+        done();
+      });
     });
 
     it('detects changes', done => {
       spyOn(component, 'validate').and.returnValue(Promise.resolve(ERROR));
-      component.submit(VALUE2)
-        .then(() => {
-          expect(detector.detectChanges).toHaveBeenCalled();
-          done();
-        });
+      component.submit(VALUE2).then(() => {
+        expect(detector.detectChanges).toHaveBeenCalled();
+        done();
+      });
     });
   });
 
   describe('validate', () => {
     it('returns Promise that resolves to null when validation function is not set', done => {
-      component.validate(VALUE2)
-        .then(result => {
-          expect(result).toBe(null);
-          done();
-        });
+      component.validate(VALUE2).then(result => {
+        expect(result).toBe(null);
+        done();
+      });
     });
 
     it('returns Promise that resolves to value returned by validation function', done => {
       component.validationFn = value => ERROR;
-      component.validate(VALUE2)
-        .then(result => {
-          expect(result).toBe(ERROR);
-          done();
-        });
+      component.validate(VALUE2).then(result => {
+        expect(result).toBe(ERROR);
+        done();
+      });
     });
   });
 
@@ -112,5 +105,4 @@ describe('EditableComponent', () => {
       expect(component.editing).toBe(false);
     });
   });
-
 });

--- a/src/app/common/editable/editable.component.ts
+++ b/src/app/common/editable/editable.component.ts
@@ -1,7 +1,12 @@
-import { Component, EventEmitter, Input, Output, ChangeDetectorRef } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ChangeDetectorRef
+} from '@angular/core';
 
 export abstract class EditableComponent {
-
   @Input() value;
   @Input() placeholder = 'No value set';
   @Input() validationFn: (value) => string | Promise<string>;
@@ -34,5 +39,4 @@ export abstract class EditableComponent {
     this.errorMessage = null;
     this.editing = false;
   }
-
 }

--- a/src/app/common/forms.service.ts
+++ b/src/app/common/forms.service.ts
@@ -5,7 +5,7 @@ import {
   DynamicCheckboxModel,
   DynamicInputModel,
   DynamicTextAreaModel,
-  DynamicSelectModel,
+  DynamicSelectModel
 } from '@ng-dynamic-forms/core';
 
 export interface ConfiguredConfigurationProperty extends ConfigurationProperty {
@@ -22,7 +22,7 @@ export class FormFactoryService {
       | Map<string, ConfigurationProperty>
       | Map<string, any>
       | {},
-    values: any = {},
+    values: any = {}
   ): DynamicFormControlModel[] {
     const answer = <DynamicFormControlModel[]>[];
     for (const key in properties) {
@@ -32,8 +32,10 @@ export class FormFactoryService {
       const field = <ConfiguredConfigurationProperty>properties[key];
       const value = values[key];
       let formField: any;
-      const validators = field.required ? {'required': null} : {};
-      const errorMessages = field.required ? {'required': '{{label}} is required'} : {};
+      const validators = field.required ? { required: null } : {};
+      const errorMessages = field.required
+        ? { required: '{{label}} is required' }
+        : {};
       let type = (field.type || '').toLowerCase();
       // first normalize the type
       switch (type) {
@@ -50,7 +52,7 @@ export class FormFactoryService {
         case 'hidden':
           break;
         default:
-          type = (field.enum && field.enum.length) ? 'select' : 'text';
+          type = field.enum && field.enum.length ? 'select' : 'text';
           break;
       }
       // then use the appropriate ng2 dynamic forms constructor
@@ -60,17 +62,17 @@ export class FormFactoryService {
             id: key,
             label: field.displayName || key,
             hint: field.description,
-            value: value || field.value || field.defaultValue,
+            value: value || field.value || field.defaultValue
           },
           {
             element: {
-              control: 'element-control checkbox',
+              control: 'element-control checkbox'
             },
             grid: {
               control: 'col-sm-offset-3 col-sm-9',
-              label: '',
-            },
-          },
+              label: ''
+            }
+          }
         );
       } else if (type === 'textarea') {
         formField = new DynamicTextAreaModel(
@@ -83,17 +85,17 @@ export class FormFactoryService {
             rows: field.rows,
             cols: field.cols,
             validators: validators,
-            errorMessages: errorMessages,
+            errorMessages: errorMessages
           },
           {
             element: {
-              label: 'control-label',
+              label: 'control-label'
             },
             grid: {
               control: 'col-sm-9',
-              label: 'col-sm-3',
-            },
-          },
+              label: 'col-sm-3'
+            }
+          }
         );
       } else if (type === 'select') {
         formField = new DynamicSelectModel(
@@ -106,17 +108,17 @@ export class FormFactoryService {
             required: field.required,
             validators: validators,
             errorMessages: errorMessages,
-            options: field.enum,
+            options: field.enum
           },
           {
             element: {
-              label: 'control-label',
+              label: 'control-label'
             },
             grid: {
               control: 'col-sm-9',
-              label: 'col-sm-3',
-            },
-          },
+              label: 'col-sm-3'
+            }
+          }
         );
       } else {
         if (field.secret) {
@@ -129,25 +131,27 @@ export class FormFactoryService {
             inputType: type,
             value: value || field.value || field.defaultValue,
             hint: field.description,
-            list: field.enum ? (<Array<any>>field.enum).map(val => {
-              if (typeof val === 'string') {
-                return val;
-              }
-              return val['value'];
-            }) : undefined,
+            list: field.enum
+              ? (<Array<any>>field.enum).map(val => {
+                  if (typeof val === 'string') {
+                    return val;
+                  }
+                  return val['value'];
+                })
+              : undefined,
             required: field.required,
             validators: validators,
-            errorMessages: errorMessages,
+            errorMessages: errorMessages
           },
           {
             element: {
-              label: 'control-label',
+              label: 'control-label'
             },
             grid: {
               control: 'col-sm-9',
-              label: 'col-sm-3',
-            },
-          },
+              label: 'col-sm-3'
+            }
+          }
         );
       }
 

--- a/src/app/common/loading/loading.component.scss
+++ b/src/app/common/loading/loading.component.scss
@@ -1,4 +1,4 @@
-@import "patternfly-sass/assets/stylesheets/patternfly/variables";
+@import 'patternfly-sass/assets/stylesheets/patternfly/variables';
 
 .loading {
   position: absolute;

--- a/src/app/common/loading/loading.component.spec.ts
+++ b/src/app/common/loading/loading.component.spec.ts
@@ -12,9 +12,9 @@ describe('LoadingComponent', () => {
   beforeEach(
     async(() => {
       TestBed.configureTestingModule({
-        declarations: [LoadingComponent],
+        declarations: [LoadingComponent]
       }).compileComponents();
-    }),
+    })
   );
 
   beforeEach(() => {

--- a/src/app/common/loading/loading.component.ts
+++ b/src/app/common/loading/loading.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 @Component({
   selector: 'syndesis-loading',
   templateUrl: './loading.component.html',
-  styleUrls: ['./loading.component.scss'],
+  styleUrls: ['./loading.component.scss']
 })
 export class LoadingComponent {
   @Input() loading: boolean;

--- a/src/app/common/modal/modal.component.ts
+++ b/src/app/common/modal/modal.component.ts
@@ -6,13 +6,13 @@ import {
   Input,
   Output,
   ViewChild,
-  TemplateRef,
+  TemplateRef
 } from '@angular/core';
 import { ModalService } from './modal.service';
 
 @Component({
   selector: 'syndesis-modal',
-  templateUrl: './modal.component.html',
+  templateUrl: './modal.component.html'
 })
 export class ModalComponent implements OnInit, OnDestroy, OnChanges {
   @Input() id = 'modal';

--- a/src/app/common/modal/modal.service.ts
+++ b/src/app/common/modal/modal.service.ts
@@ -5,10 +5,9 @@ import { Modal } from './modal';
 
 @Injectable()
 export class ModalService {
-
   private registeredModals = new Map<string, Modal>();
 
-  constructor(private bsModalService: BsModalService) { }
+  constructor(private bsModalService: BsModalService) {}
 
   registerModal(id: string, template: TemplateRef<any>): void {
     this.registeredModals.set(id, { template: template });
@@ -21,7 +20,8 @@ export class ModalService {
   show(id = 'modal'): Promise<Modal> {
     const modal = this.registeredModals.get(id);
     modal.bsModalRef = this.bsModalService.show(modal.template);
-    return this.bsModalService.onHide.take(1)
+    return this.bsModalService.onHide
+      .take(1)
       .toPromise()
       .then(_ => modal);
   }

--- a/src/app/common/navigation.service.ts
+++ b/src/app/common/navigation.service.ts
@@ -30,5 +30,4 @@ export class NavigationService {
   private get setupVerticalNavigation(): any {
     return this.jQuery['setupVerticalNavigation'];
   }
-
 }

--- a/src/app/common/object-property-filter.pipe.spec.ts
+++ b/src/app/common/object-property-filter.pipe.spec.ts
@@ -9,9 +9,9 @@ describe('ObjectPropertyFilterPipe', () => {
       number: 4,
       stuff: {
         inner: {
-          name: 'foo',
-        },
-      },
+          name: 'foo'
+        }
+      }
     },
     {
       name: 'bar',
@@ -19,9 +19,9 @@ describe('ObjectPropertyFilterPipe', () => {
       number: 5,
       stuff: {
         inner: {
-          name: 'bar',
-        },
-      },
+          name: 'bar'
+        }
+      }
     },
     {
       name: 'bar2',
@@ -29,9 +29,9 @@ describe('ObjectPropertyFilterPipe', () => {
       number: 6,
       stuff: {
         inner: {
-          name: 'bar2',
-        },
-      },
+          name: 'bar2'
+        }
+      }
     },
     {
       name: 'yum',
@@ -39,10 +39,10 @@ describe('ObjectPropertyFilterPipe', () => {
       number: 7,
       stuff: {
         inner: {
-          name: 'yum',
-        },
-      },
-    },
+          name: 'yum'
+        }
+      }
+    }
   ];
 
   beforeEach(() => {
@@ -52,7 +52,7 @@ describe('ObjectPropertyFilterPipe', () => {
   it('will return a filtered list of objects', () => {
     const results = pipe.transform(testArray, {
       filter: 'ba',
-      propertyName: 'name',
+      propertyName: 'name'
     });
     expect(results.length).toEqual(2);
     const result = results.shift();
@@ -64,7 +64,7 @@ describe('ObjectPropertyFilterPipe', () => {
   it('will not return any objects if the filter doesnt match', () => {
     const results = pipe.transform(testArray, {
       filter: 'bla',
-      propertyName: 'name',
+      propertyName: 'name'
     });
     expect(results.length).toEqual(0);
   });
@@ -72,7 +72,7 @@ describe('ObjectPropertyFilterPipe', () => {
   it('can filter on a numeric value', () => {
     const results = pipe.transform(testArray, {
       filter: 4,
-      propertyName: 'number',
+      propertyName: 'number'
     });
     expect(results.length).toEqual(1);
     const result = results.shift();
@@ -82,7 +82,7 @@ describe('ObjectPropertyFilterPipe', () => {
   it('can filter on a boolean', () => {
     const results = pipe.transform(testArray, {
       filter: true,
-      propertyName: 'yes',
+      propertyName: 'yes'
     });
     expect(results.length).toEqual(1);
     const result = results.shift();
@@ -93,10 +93,10 @@ describe('ObjectPropertyFilterPipe', () => {
     const results = pipe.transform(testArray, {
       filter: {
         inner: {
-          name: 'bar',
-        },
+          name: 'bar'
+        }
       },
-      propertyName: 'stuff',
+      propertyName: 'stuff'
     });
     expect(results.length).toEqual(1);
     const result = results.shift();
@@ -106,7 +106,7 @@ describe('ObjectPropertyFilterPipe', () => {
   it('can descend into an object', () => {
     const results = pipe.transform(testArray, {
       filter: 'ba',
-      propertyName: 'stuff.inner.name',
+      propertyName: 'stuff.inner.name'
     });
     expect(results.length).toEqual(2);
     const result = results.shift();
@@ -118,7 +118,7 @@ describe('ObjectPropertyFilterPipe', () => {
   it('lets me use a function', () => {
     const results = pipe.transform(testArray, {
       filter: (val: any) => val === 'bar',
-      propertyName: 'name',
+      propertyName: 'name'
     });
     expect(results.length).toEqual(1);
   });

--- a/src/app/common/object-property-filter.pipe.ts
+++ b/src/app/common/object-property-filter.pipe.ts
@@ -19,7 +19,7 @@ export function getPropertyValue(obj: any, prop: string): any {
 
 @Pipe({
   name: 'objectPropertyFilter',
-  pure: false,
+  pure: false
 })
 export class ObjectPropertyFilterPipe implements PipeTransform {
   transform(objects: any[], config: ObjectPropertyFilterConfig) {
@@ -35,7 +35,7 @@ export class ObjectPropertyFilterPipe implements PipeTransform {
       switch (typeof config.filter) {
         case 'string':
           if (config.exact && config.filter.length > 0) {
-            return (<string>value) === config.filter;
+            return <string>value === config.filter;
           }
           return (
             (<string>value)

--- a/src/app/common/object-property-sort.pipe.spec.ts
+++ b/src/app/common/object-property-sort.pipe.spec.ts
@@ -9,9 +9,9 @@ describe('ObjectPropertySortPipe', () => {
       number: 8,
       stuff: {
         inner: {
-          name: 'foo',
-        },
-      },
+          name: 'foo'
+        }
+      }
     },
     {
       name: 'bar',
@@ -19,9 +19,9 @@ describe('ObjectPropertySortPipe', () => {
       number: 5,
       stuff: {
         inner: {
-          name: 'bar',
-        },
-      },
+          name: 'bar'
+        }
+      }
     },
     {
       name: 'bar2',
@@ -29,9 +29,9 @@ describe('ObjectPropertySortPipe', () => {
       number: 6,
       stuff: {
         inner: {
-          name: 'bar2',
-        },
-      },
+          name: 'bar2'
+        }
+      }
     },
     {
       name: 'yum',
@@ -39,10 +39,10 @@ describe('ObjectPropertySortPipe', () => {
       number: 7,
       stuff: {
         inner: {
-          name: 'yum',
-        },
-      },
-    },
+          name: 'yum'
+        }
+      }
+    }
   ];
 
   beforeEach(() => {
@@ -52,7 +52,7 @@ describe('ObjectPropertySortPipe', () => {
   it('will sort an array of objects', () => {
     const results = pipe.transform(testArray, {
       sortField: 'name',
-      descending: false,
+      descending: false
     });
 
     expect(results.length).toEqual(4);
@@ -69,7 +69,7 @@ describe('ObjectPropertySortPipe', () => {
   it('will sort an array of objects in reverse', () => {
     const results = pipe.transform(testArray, {
       sortField: 'name',
-      descending: true,
+      descending: true
     });
 
     expect(results.length).toEqual(4);
@@ -86,7 +86,7 @@ describe('ObjectPropertySortPipe', () => {
   it('will sort an array of objects using numbers', () => {
     const results = pipe.transform(testArray, {
       sortField: 'number',
-      descending: false,
+      descending: false
     });
 
     expect(results.length).toEqual(4);

--- a/src/app/common/object-property-sort.pipe.ts
+++ b/src/app/common/object-property-sort.pipe.ts
@@ -7,7 +7,7 @@ export class ObjectPropertySortConfig {
 }
 
 @Pipe({
-  name: 'objectPropertySort',
+  name: 'objectPropertySort'
 })
 export class ObjectPropertySortPipe implements PipeTransform {
   transform(objects: any[], config: ObjectPropertySortConfig) {

--- a/src/app/common/titleize.pipe.ts
+++ b/src/app/common/titleize.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: 'titleize',
+  name: 'titleize'
 })
 export class TitleizePipe implements PipeTransform {
   transform(value: string, config: any) {

--- a/src/app/common/to-id.pipe.ts
+++ b/src/app/common/to-id.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: 'toId',
+  name: 'toId'
 })
 /**
  * Converts and normalizes a string to a valid and standardized

--- a/src/app/common/truncate-characters.pipe.ts
+++ b/src/app/common/truncate-characters.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: 'truncate',
+  name: 'truncate'
 })
 export class TruncateCharactersPipe implements PipeTransform {
   transform(value: string, limit = 40, trail = '…'): string {

--- a/src/app/common/truncate-words.pipe.ts
+++ b/src/app/common/truncate-words.pipe.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-  name: 'words',
+  name: 'words'
 })
 export class TruncateWordsPipe implements PipeTransform {
   transform(value: string, limit = 40, trail = '…'): string {

--- a/src/app/common/ui-patternfly/list-toolbar/list-toolbar.component.spec.ts
+++ b/src/app/common/ui-patternfly/list-toolbar/list-toolbar.component.spec.ts
@@ -12,13 +12,10 @@ describe('ListToolbarComponent', () => {
   beforeEach(
     async(() => {
       TestBed.configureTestingModule({
-        imports: [
-          RouterTestingModule.withRoutes([]),
-          ToolbarModule,
-        ],
-        declarations: [ListToolbarComponent],
+        imports: [RouterTestingModule.withRoutes([]), ToolbarModule],
+        declarations: [ListToolbarComponent]
       }).compileComponents();
-    }),
+    })
   );
 
   beforeEach(() => {

--- a/src/app/common/ui-patternfly/list-toolbar/list-toolbar.component.ts
+++ b/src/app/common/ui-patternfly/list-toolbar/list-toolbar.component.ts
@@ -5,7 +5,7 @@ import {
   Output,
   OnDestroy,
   OnInit,
-  TemplateRef,
+  TemplateRef
 } from '@angular/core';
 
 import { Subject } from 'rxjs/Subject';
@@ -20,7 +20,7 @@ import {
   SortConfig,
   SortField,
   SortEvent,
-  ToolbarConfig,
+  ToolbarConfig
 } from 'patternfly-ng';
 
 import { ObjectPropertyFilterPipe } from '../../object-property-filter.pipe';
@@ -29,7 +29,7 @@ import { ObjectPropertySortPipe } from '../../object-property-sort.pipe';
 @Component({
   selector: 'syndesis-list-toolbar',
   templateUrl: './list-toolbar.component.html',
-  styleUrls: ['./list-toolbar.component.scss'],
+  styleUrls: ['./list-toolbar.component.scss']
 })
 export class ListToolbarComponent<T> implements OnInit, OnDestroy {
   @Input() items: Observable<Array<T>> = Observable.empty();
@@ -51,31 +51,35 @@ export class ListToolbarComponent<T> implements OnInit, OnDestroy {
 
   ngOnInit() {
     const filterConfig = {
-      fields : [{
-        id          : 'name',
-        title       : 'Name',
-        placeholder : 'Filter by Name...',
-        type        : 'text',
-      }],
-      appliedFilters : [],
+      fields: [
+        {
+          id: 'name',
+          title: 'Name',
+          placeholder: 'Filter by Name...',
+          type: 'text'
+        }
+      ],
+      appliedFilters: []
     } as FilterConfig;
     filterConfig.fields.push(...this.filterFields);
     const sortConfig = {
-      fields : [{
-        id       : 'name',
-        title    : 'Name',
-        sortType : 'alpha',
-      }],
-      isAscending : this.isAscendingSort,
+      fields: [
+        {
+          id: 'name',
+          title: 'Name',
+          sortType: 'alpha'
+        }
+      ],
+      isAscending: this.isAscendingSort
     } as SortConfig;
 
     this.toolbarConfig = {
-      filterConfig : filterConfig,
-      sortConfig   : sortConfig,
+      filterConfig: filterConfig,
+      sortConfig: sortConfig
     } as ToolbarConfig;
 
     this.subscription = this.items
-      .do(items => this.allItems = items)
+      .do(items => (this.allItems = items))
       .do(items => {
         if (!this.filterTags) {
           return;
@@ -83,14 +87,16 @@ export class ListToolbarComponent<T> implements OnInit, OnDestroy {
         if (items.find(item => item['tags'])) {
           if (!filterConfig.fields.find(field => field.id === 'tag')) {
             filterConfig.fields.push({
-              id          : 'tag',
-              title       : 'Tag',
-              placeholder : 'Filter by tag...',
-              type        : 'typeahead',
+              id: 'tag',
+              title: 'Tag',
+              placeholder: 'Filter by tag...',
+              type: 'typeahead'
             });
           }
         } else {
-          const index = filterConfig.fields.findIndex(field => field.id === 'tag');
+          const index = filterConfig.fields.findIndex(
+            field => field.id === 'tag'
+          );
           if (index >= 0) {
             filterConfig.fields.splice(index, 1);
           }
@@ -105,16 +111,22 @@ export class ListToolbarComponent<T> implements OnInit, OnDestroy {
   }
 
   filter(): void {
-    const result = this.toolbarConfig.filterConfig.appliedFilters
-      .reduce((items, filter) => filter.field.id === 'tag'
-        ? items.filter(item => Array.isArray(item['tags'])
-          ? item['tags'].some(tag => tag === filter.query.value)
-          : false)
-        : this.propertyFilter.transform(items, {
-            filter: filter.value,
-            propertyName: filter.field.id,
-            exact: filter.field.type !== 'text',
-          }), this.allItems);
+    const result = this.toolbarConfig.filterConfig.appliedFilters.reduce(
+      (items, filter) =>
+        filter.field.id === 'tag'
+          ? items.filter(
+              item =>
+                Array.isArray(item['tags'])
+                  ? item['tags'].some(tag => tag === filter.query.value)
+                  : false
+            )
+          : this.propertyFilter.transform(items, {
+              filter: filter.value,
+              propertyName: filter.field.id,
+              exact: filter.field.type !== 'text'
+            }),
+      this.allItems
+    );
     this.toolbarConfig.filterConfig.resultsCount = result.length;
     this.itemsFiltered = result;
     this.sort();
@@ -126,8 +138,8 @@ export class ListToolbarComponent<T> implements OnInit, OnDestroy {
       this.isAscendingSort = $event.isAscending;
     }
     const result = this.propertySorter.transform(this.itemsFiltered, {
-      sortField  : this.currentSortFieldId || 'name',
-      descending : !this.isAscendingSort,
+      sortField: this.currentSortFieldId || 'name',
+      descending: !this.isAscendingSort
     });
     this.filteredItems.next(result);
   }

--- a/src/app/common/ui-patternfly/syndesis-form-control.component.spec.ts
+++ b/src/app/common/ui-patternfly/syndesis-form-control.component.spec.ts
@@ -1,197 +1,205 @@
-import { TestBed, async, inject, ComponentFixture } from '@angular/core/testing';
+import {
+  TestBed,
+  async,
+  inject,
+  ComponentFixture
+} from '@angular/core/testing';
 import { DebugElement, SimpleChange } from '@angular/core';
 import { ReactiveFormsModule, FormGroup, FormControl } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { TextMaskModule } from 'angular2-text-mask';
 import {
-    DynamicFormsCoreModule,
-    DynamicFormService,
-    DynamicCheckboxModel,
-    DynamicCheckboxGroupModel,
-    DynamicDatePickerModel,
-    DynamicEditorModel,
-    DynamicFileUploadModel,
-    DynamicFormArrayModel,
-    DynamicFormControlModel,
-    DynamicFormGroupModel,
-    DynamicInputModel,
-    DynamicRadioGroupModel,
-    DynamicSelectModel,
-    DynamicSliderModel,
-    DynamicSwitchModel,
-    DynamicTextAreaModel,
-    DynamicTimePickerModel,
+  DynamicFormsCoreModule,
+  DynamicFormService,
+  DynamicCheckboxModel,
+  DynamicCheckboxGroupModel,
+  DynamicDatePickerModel,
+  DynamicEditorModel,
+  DynamicFileUploadModel,
+  DynamicFormArrayModel,
+  DynamicFormControlModel,
+  DynamicFormGroupModel,
+  DynamicInputModel,
+  DynamicRadioGroupModel,
+  DynamicSelectModel,
+  DynamicSliderModel,
+  DynamicSwitchModel,
+  DynamicTextAreaModel,
+  DynamicTimePickerModel
 } from '@ng-dynamic-forms/core';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
-import { SyndesisFormControlType, SyndesisFormComponent } from './syndesis-form-control.component';
+import {
+  SyndesisFormControlType,
+  SyndesisFormComponent
+} from './syndesis-form-control.component';
 
 describe('SyndesisFormComponent test suite', () => {
+  const formModel = [
+    new DynamicCheckboxModel({ id: 'checkbox' }),
+    new DynamicCheckboxGroupModel({ id: 'checkboxGroup', group: [] }),
+    new DynamicDatePickerModel({ id: 'datepicker' }),
+    new DynamicEditorModel({ id: 'editor' }),
+    new DynamicFileUploadModel({ id: 'upload', url: '' }),
+    new DynamicFormArrayModel({ id: 'formArray', groupFactory: () => [] }),
+    new DynamicFormGroupModel({ id: 'formGroup', group: [] }),
+    new DynamicInputModel({ id: 'input', maxLength: 51 }),
+    new DynamicRadioGroupModel({ id: 'radioGroup' }),
+    new DynamicSelectModel({
+      id: 'select',
+      options: [{ value: 'One' }, { value: 'Two' }],
+      value: 'One'
+    }),
+    new DynamicSliderModel({ id: 'slider' }),
+    new DynamicSwitchModel({ id: 'switch' }),
+    new DynamicTextAreaModel({ id: 'textarea' }),
+    new DynamicTimePickerModel({ id: 'timepicker' })
+  ];
+  const testModel = formModel[7] as DynamicInputModel;
+  let formGroup: FormGroup;
+  let fixture: ComponentFixture<SyndesisFormComponent>;
+  let component: SyndesisFormComponent;
+  let debugElement: DebugElement;
+  let testElement: DebugElement;
 
-    const formModel = [
-            new DynamicCheckboxModel({id: 'checkbox'}),
-            new DynamicCheckboxGroupModel({id: 'checkboxGroup', group: []}),
-            new DynamicDatePickerModel({id: 'datepicker'}),
-            new DynamicEditorModel({id: 'editor'}),
-            new DynamicFileUploadModel({id: 'upload', url: ''}),
-            new DynamicFormArrayModel({id: 'formArray', groupFactory: () => []}),
-            new DynamicFormGroupModel({id: 'formGroup', group: []}),
-            new DynamicInputModel({id: 'input', maxLength: 51}),
-            new DynamicRadioGroupModel({id: 'radioGroup'}),
-            new DynamicSelectModel({id: 'select', options: [{value: 'One'}, {value: 'Two'}], value: 'One'}),
-            new DynamicSliderModel({id: 'slider'}),
-            new DynamicSwitchModel({id: 'switch'}),
-            new DynamicTextAreaModel({id: 'textarea'}),
-            new DynamicTimePickerModel({id: 'timepicker'}),
-        ];
-    const testModel = formModel[7] as DynamicInputModel;
-    let formGroup: FormGroup;
-    let fixture: ComponentFixture<SyndesisFormComponent>;
-    let component: SyndesisFormComponent;
-    let debugElement: DebugElement;
-    let testElement: DebugElement;
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          ReactiveFormsModule,
+          DynamicFormsCoreModule.forRoot(),
+          TextMaskModule,
+          TooltipModule.forRoot()
+        ],
+        declarations: [SyndesisFormComponent]
+      })
+        .compileComponents()
+        .then(() => {
+          fixture = TestBed.createComponent(SyndesisFormComponent);
 
-    beforeEach(async(() => {
-
-        TestBed.configureTestingModule({
-
-            imports: [ReactiveFormsModule, DynamicFormsCoreModule.forRoot(), TextMaskModule, TooltipModule.forRoot()],
-            declarations: [SyndesisFormComponent],
-
-        }).compileComponents().then(() => {
-
-            fixture = TestBed.createComponent(SyndesisFormComponent);
-
-            component = fixture.componentInstance;
-            debugElement = fixture.debugElement;
+          component = fixture.componentInstance;
+          debugElement = fixture.debugElement;
         });
-    }));
+    })
+  );
 
-    beforeEach(inject([DynamicFormService], (service: DynamicFormService) => {
+  beforeEach(
+    inject([DynamicFormService], (service: DynamicFormService) => {
+      formGroup = service.createFormGroup(formModel);
 
-        formGroup = service.createFormGroup(formModel);
+      component.group = formGroup;
+      component.model = testModel;
 
-        component.group = formGroup;
-        component.model = testModel;
+      component.ngOnChanges({
+        group: new SimpleChange(null, component.group, true),
+        model: new SimpleChange(null, component.model, true)
+      });
 
-        component.ngOnChanges({
+      fixture.detectChanges();
 
-            group: new SimpleChange(null, component.group, true),
-            model: new SimpleChange(null, component.model, true),
-        });
+      testElement = debugElement.query(By.css(`input[id='${testModel.id}']`));
+    })
+  );
 
-        fixture.detectChanges();
+  it('should initialize correctly', () => {
+    expect(component.context).toBeNull();
+    expect(component.control instanceof FormControl).toBe(true);
+    expect(component.group instanceof FormGroup).toBe(true);
+    expect(component.model instanceof DynamicFormControlModel).toBe(true);
+    expect(component.hasErrorMessaging).toBe(false);
+    expect(component.asBootstrapFormGroup).toBe(true);
 
-        testElement = debugElement.query(By.css(`input[id='${testModel.id}']`));
-    }));
+    expect(component.onControlValueChanges).toBeDefined();
+    expect(component.onModelDisabledUpdates).toBeDefined();
+    expect(component.onModelValueUpdates).toBeDefined();
 
-    it('should initialize correctly', () => {
+    expect(component.blur).toBeDefined();
+    expect(component.change).toBeDefined();
+    expect(component.focus).toBeDefined();
 
-        expect(component.context).toBeNull();
-        expect(component.control instanceof FormControl).toBe(true);
-        expect(component.group instanceof FormGroup).toBe(true);
-        expect(component.model instanceof DynamicFormControlModel).toBe(true);
-        expect(component.hasErrorMessaging).toBe(false);
-        expect(component.asBootstrapFormGroup).toBe(true);
+    expect(component.onValueChange).toBeDefined();
+    expect(component.onFocusChange).toBeDefined();
 
-        expect(component.onControlValueChanges).toBeDefined();
-        expect(component.onModelDisabledUpdates).toBeDefined();
-        expect(component.onModelValueUpdates).toBeDefined();
+    expect(component.isValid).toBe(true);
+    expect(component.isInvalid).toBe(false);
+    expect(component.showErrorMessages).toBe(false);
 
-        expect(component.blur).toBeDefined();
-        expect(component.change).toBeDefined();
-        expect(component.focus).toBeDefined();
+    expect(component.type).toEqual(SyndesisFormControlType.Input);
+  });
 
-        expect(component.onValueChange).toBeDefined();
-        expect(component.onFocusChange).toBeDefined();
+  it('should have an input element', () => {
+    expect(testElement instanceof DebugElement).toBe(true);
+  });
 
-        expect(component.isValid).toBe(true);
-        expect(component.isInvalid).toBe(false);
-        expect(component.showErrorMessages).toBe(false);
+  it('should listen to native focus and blur events', () => {
+    spyOn(component, 'onFocusChange');
 
-        expect(component.type).toEqual(SyndesisFormControlType.Input);
-    });
+    testElement.triggerEventHandler('focus', null);
+    testElement.triggerEventHandler('blur', null);
 
-    it('should have an input element', () => {
+    expect(component.onFocusChange).toHaveBeenCalledTimes(2);
+  });
 
-        expect(testElement instanceof DebugElement).toBe(true);
-    });
+  it('should listen to native change event', () => {
+    spyOn(component, 'onValueChange');
 
-    it('should listen to native focus and blur events', () => {
+    testElement.triggerEventHandler('change', null);
 
-        spyOn(component, 'onFocusChange');
+    expect(component.onValueChange).toHaveBeenCalled();
+  });
 
-        testElement.triggerEventHandler('focus', null);
-        testElement.triggerEventHandler('blur', null);
+  it('should update model value when control value changes', () => {
+    spyOn(component, 'onControlValueChanges');
 
-        expect(component.onFocusChange).toHaveBeenCalledTimes(2);
-    });
+    component.control.setValue('test');
 
-    it('should listen to native change event', () => {
+    expect(component.onControlValueChanges).toHaveBeenCalled();
+  });
 
-        spyOn(component, 'onValueChange');
+  it('should update control value when model value changes', () => {
+    spyOn(component, 'onModelValueUpdates');
 
-        testElement.triggerEventHandler('change', null);
+    testModel.valueUpdates.next('test');
 
-        expect(component.onValueChange).toHaveBeenCalled();
-    });
+    expect(component.onModelValueUpdates).toHaveBeenCalled();
+  });
 
-    it('should update model value when control value changes', () => {
+  it('should update control activation when model disabled property changes', () => {
+    spyOn(component, 'onModelDisabledUpdates');
 
-        spyOn(component, 'onControlValueChanges');
+    testModel.disabledUpdates.next(true);
 
-        component.control.setValue('test');
+    expect(component.onModelDisabledUpdates).toHaveBeenCalled();
+  });
 
-        expect(component.onControlValueChanges).toHaveBeenCalled();
-    });
+  it('should determine correct form control type', () => {
+    const testFn = SyndesisFormComponent.getFormControlType;
 
-    it('should update control value when model value changes', () => {
+    expect(testFn(formModel[0])).toEqual(SyndesisFormControlType.Checkbox);
 
-        spyOn(component, 'onModelValueUpdates');
+    expect(testFn(formModel[1])).toEqual(SyndesisFormControlType.Group);
 
-        testModel.valueUpdates.next('test');
+    expect(testFn(formModel[2])).toBeNull();
 
-        expect(component.onModelValueUpdates).toHaveBeenCalled();
-    });
+    expect(testFn(formModel[3])).toBeNull();
 
-    it('should update control activation when model disabled property changes', () => {
+    expect(testFn(formModel[4])).toBeNull();
 
-        spyOn(component, 'onModelDisabledUpdates');
+    expect(testFn(formModel[5])).toEqual(SyndesisFormControlType.Array);
 
-        testModel.disabledUpdates.next(true);
+    expect(testFn(formModel[6])).toEqual(SyndesisFormControlType.Group);
 
-        expect(component.onModelDisabledUpdates).toHaveBeenCalled();
-    });
+    expect(testFn(formModel[7])).toEqual(SyndesisFormControlType.Input);
 
-    it('should determine correct form control type', () => {
+    expect(testFn(formModel[8])).toEqual(SyndesisFormControlType.RadioGroup);
 
-        const testFn = SyndesisFormComponent.getFormControlType;
+    expect(testFn(formModel[9])).toEqual(SyndesisFormControlType.Select);
 
-        expect(testFn(formModel[0])).toEqual(SyndesisFormControlType.Checkbox);
+    expect(testFn(formModel[10])).toBeNull();
 
-        expect(testFn(formModel[1])).toEqual(SyndesisFormControlType.Group);
+    expect(testFn(formModel[11])).toBeNull();
 
-        expect(testFn(formModel[2])).toBeNull();
+    expect(testFn(formModel[12])).toEqual(SyndesisFormControlType.TextArea);
 
-        expect(testFn(formModel[3])).toBeNull();
-
-        expect(testFn(formModel[4])).toBeNull();
-
-        expect(testFn(formModel[5])).toEqual(SyndesisFormControlType.Array);
-
-        expect(testFn(formModel[6])).toEqual(SyndesisFormControlType.Group);
-
-        expect(testFn(formModel[7])).toEqual(SyndesisFormControlType.Input);
-
-        expect(testFn(formModel[8])).toEqual(SyndesisFormControlType.RadioGroup);
-
-        expect(testFn(formModel[9])).toEqual(SyndesisFormControlType.Select);
-
-        expect(testFn(formModel[10])).toBeNull();
-
-        expect(testFn(formModel[11])).toBeNull();
-
-        expect(testFn(formModel[12])).toEqual(SyndesisFormControlType.TextArea);
-
-        expect(testFn(formModel[13])).toBeNull();
-    });
+    expect(testFn(formModel[13])).toBeNull();
+  });
 });

--- a/src/app/common/ui-patternfly/syndesis-form-control.component.ts
+++ b/src/app/common/ui-patternfly/syndesis-form-control.component.ts
@@ -1,116 +1,114 @@
 import {
-    Component,
-    ContentChildren,
-    EventEmitter,
-    Input,
-    OnChanges,
-    Output,
-    QueryList,
-    SimpleChanges,
-    ChangeDetectorRef,
+  Component,
+  ContentChildren,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  QueryList,
+  SimpleChanges,
+  ChangeDetectorRef
 } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import {
-    DynamicFormValidationService,
-    DynamicFormControlModel,
-    DynamicFormArrayGroupModel,
-    DynamicFormControlComponent,
-    DynamicFormControlEvent,
-    DynamicTemplateDirective,
-    DYNAMIC_FORM_CONTROL_TYPE_ARRAY,
-    DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX,
-    DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX_GROUP,
-    DYNAMIC_FORM_CONTROL_TYPE_GROUP,
-    DYNAMIC_FORM_CONTROL_TYPE_INPUT,
-    DYNAMIC_FORM_CONTROL_TYPE_RADIO_GROUP,
-    DYNAMIC_FORM_CONTROL_TYPE_SELECT,
-    DYNAMIC_FORM_CONTROL_TYPE_TEXTAREA,
+  DynamicFormValidationService,
+  DynamicFormControlModel,
+  DynamicFormArrayGroupModel,
+  DynamicFormControlComponent,
+  DynamicFormControlEvent,
+  DynamicTemplateDirective,
+  DYNAMIC_FORM_CONTROL_TYPE_ARRAY,
+  DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX,
+  DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX_GROUP,
+  DYNAMIC_FORM_CONTROL_TYPE_GROUP,
+  DYNAMIC_FORM_CONTROL_TYPE_INPUT,
+  DYNAMIC_FORM_CONTROL_TYPE_RADIO_GROUP,
+  DYNAMIC_FORM_CONTROL_TYPE_SELECT,
+  DYNAMIC_FORM_CONTROL_TYPE_TEXTAREA
 } from '@ng-dynamic-forms/core';
 
 export const enum SyndesisFormControlType {
-
-    Array = 1, //'ARRAY',
-    Checkbox = 2, //'CHECKBOX',
-    Group = 3, //'GROUP',
-    Input = 4, //'INPUT',
-    RadioGroup = 5, //'RADIO_GROUP',
-    Select = 6, //'SELECT',
-    TextArea = 7, //'TEXTAREA'
+  Array = 1, //'ARRAY',
+  Checkbox = 2, //'CHECKBOX',
+  Group = 3, //'GROUP',
+  Input = 4, //'INPUT',
+  RadioGroup = 5, //'RADIO_GROUP',
+  Select = 6, //'SELECT',
+  TextArea = 7 //'TEXTAREA'
 }
 
 @Component({
-
-    moduleId: module.id,
-    selector: 'syndesis-form-control',
-    templateUrl: './syndesis-form-control.component.html',
+  moduleId: module.id,
+  selector: 'syndesis-form-control',
+  templateUrl: './syndesis-form-control.component.html',
   /* tslint:disable no-unused-css*/
-    styleUrls: ['./syndesis-form-control.scss'],
+  styleUrls: ['./syndesis-form-control.scss']
 })
-export class SyndesisFormComponent extends DynamicFormControlComponent implements OnChanges {
+export class SyndesisFormComponent extends DynamicFormControlComponent
+  implements OnChanges {
+  @ContentChildren(DynamicTemplateDirective)
+  contentTemplates: QueryList<DynamicTemplateDirective>;
+  // TODO disabling this for now as the base class is in a dependency
+  /* tslint:disable */
+  @Input('templates') inputTemplates: QueryList<DynamicTemplateDirective>;
+  /* tslint:enable */
 
-    @ContentChildren(DynamicTemplateDirective) contentTemplates: QueryList<DynamicTemplateDirective>;
-    // TODO disabling this for now as the base class is in a dependency
-    /* tslint:disable */
-    @Input('templates') inputTemplates: QueryList<DynamicTemplateDirective>;
-    /* tslint:enable */
+  @Input() asBootstrapFormGroup = true;
+  @Input() bindId = true;
+  @Input() hasErrorMessaging = false;
+  @Input() context: DynamicFormArrayGroupModel = null;
+  @Input() group: FormGroup;
+  @Input() model: DynamicFormControlModel;
 
-    @Input() asBootstrapFormGroup = true;
-    @Input() bindId = true;
-    @Input() hasErrorMessaging = false;
-    @Input() context: DynamicFormArrayGroupModel = null;
-    @Input() group: FormGroup;
-    @Input() model: DynamicFormControlModel;
+  @Output() blur = new EventEmitter<DynamicFormControlEvent>();
+  @Output() change = new EventEmitter<DynamicFormControlEvent>();
+  @Output() focus = new EventEmitter<DynamicFormControlEvent>();
 
-    @Output() blur = new EventEmitter<DynamicFormControlEvent>();
-    @Output() change = new EventEmitter<DynamicFormControlEvent>();
-    @Output() focus = new EventEmitter<DynamicFormControlEvent>();
+  type: SyndesisFormControlType | null;
 
-    type: SyndesisFormControlType | null;
+  static getFormControlType(
+    model: DynamicFormControlModel
+  ): SyndesisFormControlType | null {
+    switch (model.type) {
+      case DYNAMIC_FORM_CONTROL_TYPE_ARRAY:
+        return SyndesisFormControlType.Array;
 
-    static getFormControlType(model: DynamicFormControlModel): SyndesisFormControlType | null {
+      case DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX:
+        return SyndesisFormControlType.Checkbox;
 
-        switch (model.type) {
+      case DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX_GROUP:
+      case DYNAMIC_FORM_CONTROL_TYPE_GROUP:
+        return SyndesisFormControlType.Group;
 
-            case DYNAMIC_FORM_CONTROL_TYPE_ARRAY:
-                return SyndesisFormControlType.Array;
+      case DYNAMIC_FORM_CONTROL_TYPE_INPUT:
+        return SyndesisFormControlType.Input;
 
-            case DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX:
-                return SyndesisFormControlType.Checkbox;
+      case DYNAMIC_FORM_CONTROL_TYPE_RADIO_GROUP:
+        return SyndesisFormControlType.RadioGroup;
 
-            case DYNAMIC_FORM_CONTROL_TYPE_CHECKBOX_GROUP:
-            case DYNAMIC_FORM_CONTROL_TYPE_GROUP:
-                return SyndesisFormControlType.Group;
+      case DYNAMIC_FORM_CONTROL_TYPE_SELECT:
+        return SyndesisFormControlType.Select;
 
-            case DYNAMIC_FORM_CONTROL_TYPE_INPUT:
-                return SyndesisFormControlType.Input;
+      case DYNAMIC_FORM_CONTROL_TYPE_TEXTAREA:
+        return SyndesisFormControlType.TextArea;
 
-            case DYNAMIC_FORM_CONTROL_TYPE_RADIO_GROUP:
-                return SyndesisFormControlType.RadioGroup;
-
-            case DYNAMIC_FORM_CONTROL_TYPE_SELECT:
-                return SyndesisFormControlType.Select;
-
-            case DYNAMIC_FORM_CONTROL_TYPE_TEXTAREA:
-                return SyndesisFormControlType.TextArea;
-
-            default:
-                return null;
-        }
+      default:
+        return null;
     }
+  }
 
-    constructor(
-        protected validationService: DynamicFormValidationService,
-        protected detector: ChangeDetectorRef,
-    ) {
-        super(detector, validationService);
+  constructor(
+    protected validationService: DynamicFormValidationService,
+    protected detector: ChangeDetectorRef
+  ) {
+    super(detector, validationService);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    super.ngOnChanges(changes);
+
+    if (changes['model']) {
+      this.type = SyndesisFormComponent.getFormControlType(this.model);
     }
-
-    ngOnChanges(changes: SimpleChanges) {
-        super.ngOnChanges(changes);
-
-        if (changes['model']) {
-            this.type = SyndesisFormComponent.getFormControlType(this.model);
-        }
-    }
-
+  }
 }

--- a/src/app/common/ui-patternfly/syndesis-form-control.scss
+++ b/src/app/common/ui-patternfly/syndesis-form-control.scss
@@ -2,7 +2,8 @@
   min-width: 200px;
   word-wrap: break-word;
 }
-input:read-only, textarea:read-only {
+input:read-only,
+textarea:read-only {
   color: inherit;
   background-color: transparent;
   border: none;

--- a/src/app/common/ui-patternfly/ui-patternfly.module.ts
+++ b/src/app/common/ui-patternfly/ui-patternfly.module.ts
@@ -10,26 +10,16 @@ import { SyndesisFormComponent } from './syndesis-form-control.component';
 import { ListToolbarComponent } from './list-toolbar/list-toolbar.component';
 
 @NgModule({
-
-    imports: [
-        CommonModule,
-        ReactiveFormsModule,
-        TextMaskModule,
-        DynamicFormsCoreModule,
-        TooltipModule.forRoot(),
-        RouterModule,
-        ToolbarModule,
-    ],
-    declarations: [
-        SyndesisFormComponent,
-        ListToolbarComponent,
-    ],
-    exports: [
-        DynamicFormsCoreModule,
-        SyndesisFormComponent,
-        ListToolbarComponent,
-    ],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    TextMaskModule,
+    DynamicFormsCoreModule,
+    TooltipModule.forRoot(),
+    RouterModule,
+    ToolbarModule
+  ],
+  declarations: [SyndesisFormComponent, ListToolbarComponent],
+  exports: [DynamicFormsCoreModule, SyndesisFormComponent, ListToolbarComponent]
 })
-
-export class PatternflyUIModule {
-}
+export class PatternflyUIModule {}

--- a/src/app/common/user.service.spec.ts
+++ b/src/app/common/user.service.spec.ts
@@ -9,10 +9,8 @@ import { UserService } from './user.service';
 describe('UserService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        RestangularModule.forRoot(),
-      ],
-      providers: [UserService],
+      imports: [RestangularModule.forRoot()],
+      providers: [UserService]
     });
   });
 
@@ -20,6 +18,6 @@ describe('UserService', () => {
     'should ...',
     inject([UserService], (service: UserService) => {
       expect(service).toBeTruthy();
-    }),
+    })
   );
 });

--- a/src/app/common/user.service.ts
+++ b/src/app/common/user.service.ts
@@ -48,7 +48,9 @@ export class UserService {
    * Log the user out
    */
   logout(): Observable<any> {
-    return this.http.get(this.apiBaseUrl + '/oauth/sign_out').map((res: any) => res.json());
+    return this.http
+      .get(this.apiBaseUrl + '/oauth/sign_out')
+      .map((res: any) => res.json());
   }
 
   setUser(user: User) {
@@ -59,8 +61,12 @@ export class UserService {
     // @FIXME: `first()` is perhaps unnecessary here. Angular's Http (and HttpClient)
     //  Apis flag the observable stream as COMPLETE (and hence finish the subscription stream)
     // when the response is received, hence leaving the `.first()` RxJS call as unnecessary
-    this.restangularService.one('~').get().first().subscribe(user => {
-      this.setUser(user);
-    });
+    this.restangularService
+      .one('~')
+      .get()
+      .first()
+      .subscribe(user => {
+        this.setUser(user);
+      });
   }
 }

--- a/src/app/config.service.spec.ts
+++ b/src/app/config.service.spec.ts
@@ -18,9 +18,9 @@ describe('ConfigService', () => {
           useFactory: (backend, options) => {
             return new Http(backend, options);
           },
-          deps: [MockBackend, RequestOptions],
-        },
-      ],
+          deps: [MockBackend, RequestOptions]
+        }
+      ]
     });
   });
 
@@ -28,6 +28,6 @@ describe('ConfigService', () => {
     'should ...',
     inject([ConfigService], (service: ConfigService) => {
       expect(service).toBeTruthy();
-    }),
+    })
   );
 });

--- a/src/app/config.service.ts
+++ b/src/app/config.service.ts
@@ -29,14 +29,17 @@ export class ConfigService {
       .then(config => {
         log.debugc(
           () => 'Received config: ' + JSON.stringify(config, undefined, 2),
-          category,
+          category
         );
-        this.settingsRepository = Object.freeze({ ...this.settingsRepository, ...config });
+        this.settingsRepository = Object.freeze({
+          ...this.settingsRepository,
+          ...config
+        });
         log.debugc(
           () =>
             'Using merged config: ' +
             JSON.stringify(this.settingsRepository, undefined, 2),
-          category,
+          category
         );
         return this;
       })
@@ -45,7 +48,7 @@ export class ConfigService {
           () =>
             'Error: Configuration service unreachable! Using defaults: ' +
             JSON.stringify(this.settingsRepository),
-          category,
+          category
         );
       });
   }
@@ -60,7 +63,7 @@ export class ConfigService {
         return def;
       }
       throw new Error(
-        `Error: No setting found with the specified group [${group}]!`,
+        `Error: No setting found with the specified group [${group}]!`
       );
     }
 
@@ -73,7 +76,7 @@ export class ConfigService {
         return def;
       }
       throw new Error(
-        `Error: No setting found with the specified group/key [${group}/${key}]!`,
+        `Error: No setting found with the specified group/key [${group}/${key}]!`
       );
     }
 

--- a/src/app/connections/common/configuration/configuration.service.ts
+++ b/src/app/connections/common/configuration/configuration.service.ts
@@ -1,12 +1,14 @@
 import { Injectable } from '@angular/core';
-import { DynamicFormControlModel, DynamicInputModel } from '@ng-dynamic-forms/core';
+import {
+  DynamicFormControlModel,
+  DynamicInputModel
+} from '@ng-dynamic-forms/core';
 import { FormFactoryService } from '../../../common/forms.service';
 import { Connection } from '../../../model';
 
 @Injectable()
 export class ConnectionConfigurationService {
-
-  constructor(private formFactory: FormFactoryService) { }
+  constructor(private formFactory: FormFactoryService) {}
 
   shouldValidate(id: string) {
     switch (id) {
@@ -30,12 +32,15 @@ export class ConnectionConfigurationService {
     return sanitized;
   }
 
-  getFormModel(connection: Connection, readOnly: boolean): DynamicFormControlModel[] {
+  getFormModel(
+    connection: Connection,
+    readOnly: boolean
+  ): DynamicFormControlModel[] {
     const config = this.getFormConfig(connection);
     const formModel = this.formFactory.createFormModel(config);
     formModel
       .filter(model => model instanceof DynamicInputModel)
-      .forEach(model => (<DynamicInputModel>model).readOnly = readOnly);
+      .forEach(model => ((<DynamicInputModel>model).readOnly = readOnly));
     return formModel;
   }
 

--- a/src/app/connections/common/configuration/validation.component.ts
+++ b/src/app/connections/common/configuration/validation.component.ts
@@ -8,12 +8,13 @@ import { ConnectorStore } from '../../../store/connector/connector.store';
 @Component({
   selector: 'syndesis-connection-configuration-validation',
   templateUrl: './validation.component.html',
-  styles: [`
+  styles: [
+    `
     .alert { margin-top: 15px; margin-bottom: 0; }
-  `],
+  `
+  ]
 })
 export class ConnectionConfigurationValidationComponent {
-
   @Input() connection: Connection;
   @Input() formGroup: FormGroup;
   @Input() placement: 'left' | 'right' = 'left';
@@ -25,8 +26,8 @@ export class ConnectionConfigurationValidationComponent {
   constructor(
     private configurationService: ConnectionConfigurationService,
     private connectorStore: ConnectorStore,
-    private detector: ChangeDetectorRef,
-  ) { }
+    private detector: ChangeDetectorRef
+  ) {}
 
   showValidateButton(id: string) {
     return this.configurationService.shouldValidate(id);
@@ -66,8 +67,7 @@ export class ConnectionConfigurationValidationComponent {
           this.validating = false;
           this.detector.detectChanges();
         }, 10);
-      },
+      }
     );
   }
-
 }

--- a/src/app/connections/connections-routes.module.ts
+++ b/src/app/connections/connections-routes.module.ts
@@ -20,27 +20,27 @@ const routes: Routes = [
       {
         path: 'connection-basics',
         component: ConnectionsConnectionBasicsComponent,
-        canDeactivate: [CanDeactivateGuard],
+        canDeactivate: [CanDeactivateGuard]
       },
       {
         path: 'configure-fields',
         component: ConnectionsConfigureFieldsComponent,
-        canDeactivate: [CanDeactivateGuard],
+        canDeactivate: [CanDeactivateGuard]
       },
       {
         path: 'review',
         component: ConnectionsReviewComponent,
-        canDeactivate: [CanDeactivateGuard],
+        canDeactivate: [CanDeactivateGuard]
       },
-      { path: 'cancel', component: ConnectionsCancelComponent},
-      { path: '**', redirectTo: 'connection-basics', pathMatch: 'full' },
-    ],
+      { path: 'cancel', component: ConnectionsCancelComponent },
+      { path: '**', redirectTo: 'connection-basics', pathMatch: 'full' }
+    ]
   },
-  { path: ':id', component: ConnectionDetailPageComponent, pathMatch: 'full' },
+  { path: ':id', component: ConnectionDetailPageComponent, pathMatch: 'full' }
 ];
 
 @NgModule({
   imports: [RouterModule.forChild(routes), ConnectionsModule],
-  exports: [RouterModule],
+  exports: [RouterModule]
 })
 export class ConnectionsRoutesModule {}

--- a/src/app/connections/connections.module.ts
+++ b/src/app/connections/connections.module.ts
@@ -37,7 +37,7 @@ import { TourNgxBootstrapModule } from 'ngx-tour-ngx-bootstrap';
     ModalModule,
     BsDropdownModule,
     TagInputModule,
-    TourNgxBootstrapModule,
+    TourNgxBootstrapModule
   ],
   declarations: [
     ConnectionsCreatePage,
@@ -51,14 +51,9 @@ import { TourNgxBootstrapModule } from 'ngx-tour-ngx-bootstrap';
     ConnectionDetailBreadcrumbComponent,
     ConnectionDetailInfoComponent,
     ConnectionDetailConfigurationComponent,
-    ConnectionConfigurationValidationComponent,
+    ConnectionConfigurationValidationComponent
   ],
-  exports: [
-    ConnectionsListComponent,
-  ],
-  providers: [
-    CurrentConnectionService,
-    ConnectionConfigurationService,
-  ],
+  exports: [ConnectionsListComponent],
+  providers: [CurrentConnectionService, ConnectionConfigurationService]
 })
 export class ConnectionsModule {}

--- a/src/app/connections/create-page/cancel.component.ts
+++ b/src/app/connections/create-page/cancel.component.ts
@@ -3,17 +3,12 @@ import { ActivatedRoute, Router, RouterStateSnapshot } from '@angular/router';
 
 @Component({
   selector: 'syndesis-connections-cancel',
-  template: '',
+  template: ''
 })
 export class ConnectionsCancelComponent implements OnInit {
-
-  constructor(
-    private route: ActivatedRoute,
-    private router: Router,
-  ) {}
+  constructor(private route: ActivatedRoute, private router: Router) {}
 
   ngOnInit() {
     this.router.navigate(['../..'], { relativeTo: this.route });
   }
-
 }

--- a/src/app/connections/create-page/configure-fields/configure-fields.component.spec.ts
+++ b/src/app/connections/create-page/configure-fields/configure-fields.component.spec.ts
@@ -14,7 +14,12 @@ describe('ConnectionsConfigureFieldsComponent', () => {
     current = <CurrentConnectionService>{};
     modalService = jasmine.createSpyObj('modalService', ['show']);
     nextState = <RouterStateSnapshot>{};
-    component = new ConnectionsConfigureFieldsComponent(current, modalService, null, null);
+    component = new ConnectionsConfigureFieldsComponent(
+      current,
+      modalService,
+      null,
+      null
+    );
     component.formGroup = {};
   });
 
@@ -39,20 +44,18 @@ describe('ConnectionsConfigureFieldsComponent', () => {
 
     it('should return true when user confirms he wants to leave wizard', done => {
       modalService.show.and.returnValue(Promise.resolve({ result: true }));
-      component.canDeactivate(nextState)
-        .then(canDeactivate => {
-          expect(canDeactivate).toBe(true);
-          done();
-        });
+      component.canDeactivate(nextState).then(canDeactivate => {
+        expect(canDeactivate).toBe(true);
+        done();
+      });
     });
 
     it('should return false when user does not confirm he wants to leave wizard', done => {
       modalService.show.and.returnValue(Promise.resolve({ result: false }));
-      component.canDeactivate(nextState)
-        .then(canDeactivate => {
-          expect(canDeactivate).toBe(false);
-          done();
-        });
+      component.canDeactivate(nextState).then(canDeactivate => {
+        expect(canDeactivate).toBe(false);
+        done();
+      });
     });
 
     it('should return false when user clicked next and form is invalid', () => {
@@ -88,7 +91,10 @@ describe('ConnectionsConfigureFieldsComponent', () => {
 
   describe('touchFormFields', () => {
     it('should mark formGroup controls as touched', () => {
-      component.formGroup = new FormGroup({a: new FormControl('a'), b: new FormControl('b')});
+      component.formGroup = new FormGroup({
+        a: new FormControl('a'),
+        b: new FormControl('b')
+      });
       assertControlsTouched(false);
       component.touchFormFields();
       assertControlsTouched(true);
@@ -101,5 +107,4 @@ describe('ConnectionsConfigureFieldsComponent', () => {
       });
     }
   });
-
 });

--- a/src/app/connections/create-page/configure-fields/configure-fields.component.ts
+++ b/src/app/connections/create-page/configure-fields/configure-fields.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { RouterStateSnapshot } from '@angular/router';
 import { FormGroup } from '@angular/forms';
-import { DynamicFormControlModel, DynamicFormService } from '@ng-dynamic-forms/core';
+import {
+  DynamicFormControlModel,
+  DynamicFormService
+} from '@ng-dynamic-forms/core';
 import { Subscription } from 'rxjs/Subscription';
 
 import { CurrentConnectionService } from '../current-connection';
@@ -12,10 +15,10 @@ import { ConnectionConfigurationService } from '../../common/configuration/confi
 
 @Component({
   selector: 'syndesis-connections-configure-fields',
-  templateUrl: 'configure-fields.component.html',
+  templateUrl: 'configure-fields.component.html'
 })
-export class ConnectionsConfigureFieldsComponent implements OnInit, OnDestroy, CanComponentDeactivate {
-
+export class ConnectionsConfigureFieldsComponent
+  implements OnInit, OnDestroy, CanComponentDeactivate {
   formModel: DynamicFormControlModel[];
   formGroup: FormGroup;
   formChangesSubscription: Subscription;
@@ -24,20 +27,25 @@ export class ConnectionsConfigureFieldsComponent implements OnInit, OnDestroy, C
     public current: CurrentConnectionService,
     public modalService: ModalService,
     private configurationService: ConnectionConfigurationService,
-    private formService: DynamicFormService,
+    private formService: DynamicFormService
   ) {}
 
   ngOnInit() {
-    this.formModel = this.configurationService.getFormModel(this.connection, false);
+    this.formModel = this.configurationService.getFormModel(
+      this.connection,
+      false
+    );
     this.formGroup = this.formService.createFormGroup(this.formModel);
-    this.formChangesSubscription = this.formGroup.valueChanges.subscribe(data => {
-      Object.keys(data).forEach(key => {
-        if (data[key] === null) {
-          delete data[key];
-        }
-      });
-      this.connection.configuredProperties = data;
-    });
+    this.formChangesSubscription = this.formGroup.valueChanges.subscribe(
+      data => {
+        Object.keys(data).forEach(key => {
+          if (data[key] === null) {
+            delete data[key];
+          }
+        });
+        this.connection.configuredProperties = data;
+      }
+    );
   }
 
   ngOnDestroy() {
@@ -70,7 +78,9 @@ export class ConnectionsConfigureFieldsComponent implements OnInit, OnDestroy, C
   }
 
   private clickedNextButFormInvalid(nextState: RouterStateSnapshot) {
-    return nextState.url === '/connections/create/review' && this.formGroup.invalid;
+    return (
+      nextState.url === '/connections/create/review' && this.formGroup.invalid
+    );
   }
 
   // This will trigger validation
@@ -79,5 +89,4 @@ export class ConnectionsConfigureFieldsComponent implements OnInit, OnDestroy, C
       this.formGroup.get(key).markAsTouched();
     });
   }
-
 }

--- a/src/app/connections/create-page/connection-basics/connection-basics.component.ts
+++ b/src/app/connections/create-page/connection-basics/connection-basics.component.ts
@@ -11,18 +11,19 @@ import { UserService } from '../../../common/user.service';
 
 @Component({
   selector: 'syndesis-connections-connection-basics',
-  templateUrl: 'connection-basics.component.html',
+  templateUrl: 'connection-basics.component.html'
 })
 export class ConnectionsConnectionBasicsComponent implements OnInit {
-
   loading: Observable<boolean>;
   connectors: Observable<Connectors>;
   filteredConnectors: Subject<Connectors> = new BehaviorSubject(<Connectors>{});
 
-  constructor(private current: CurrentConnectionService,
-              private connectorStore: ConnectorStore,
-              public tourService: TourService,
-              private userService: UserService) {
+  constructor(
+    private current: CurrentConnectionService,
+    private connectorStore: ConnectorStore,
+    public tourService: TourService,
+    private userService: UserService
+  ) {
     this.loading = connectorStore.loading;
     this.connectors = connectorStore.list;
   }
@@ -34,21 +35,23 @@ export class ConnectionsConnectionBasicsComponent implements OnInit {
      * If guided tour state is set to be shown (i.e. true), then show it for this page, otherwise don't.
      */
     if (this.userService.getTourState() === true) {
-      this.tourService.initialize([ {
+      this.tourService.initialize([
+        {
           route: 'connections/create/connection-basics',
           anchorId: 'connections.type',
-          content: 'A connection represents a specific application that you want to obtain data from or send data to.',
+          content:
+            'A connection represents a specific application that you want to obtain data from or send data to.',
           placement: 'left',
-          title: 'Connection',
-        } ],
-      );
+          title: 'Connection'
+        }
+      ]);
       setTimeout(() => this.tourService.start());
     }
   }
 
   onSelected(connector: Connector) {
     const connection = TypeFactory.createConnection();
-    const plain = connector[ 'plain' ];
+    const plain = connector['plain'];
     if (plain && typeof plain === 'function') {
       connection.connector = plain();
     } else {
@@ -58,5 +61,4 @@ export class ConnectionsConnectionBasicsComponent implements OnInit {
     connection.connectorId = connector.id;
     this.current.connection = connection;
   }
-
 }

--- a/src/app/connections/create-page/create-page.component.ts
+++ b/src/app/connections/create-page/create-page.component.ts
@@ -5,7 +5,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { NavigationService } from '../../common/navigation.service';
 import {
   CurrentConnectionService,
-  ConnectionEvent,
+  ConnectionEvent
 } from './current-connection';
 import { Connection, TypeFactory } from '../../model';
 import { log, getCategory } from '../../logging';
@@ -15,18 +15,18 @@ const category = getCategory('Connections');
 @Component({
   selector: 'syndesis-connection-create-page',
   templateUrl: 'create-page.component.html',
-  styleUrls: [ './create-page.component.scss' ],
+  styleUrls: ['./create-page.component.scss']
 })
 export class ConnectionsCreatePage implements OnInit, OnDestroy {
   private routerEventsSubscription: Subscription;
 
-  constructor(private current: CurrentConnectionService,
-              private route: ActivatedRoute,
-              private router: Router,
-              private nav: NavigationService,
-              private detector: ChangeDetectorRef,
-              ) {
-  }
+  constructor(
+    private current: CurrentConnectionService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private nav: NavigationService,
+    private detector: ChangeDetectorRef
+  ) {}
 
   get connection(): Connection {
     return this.current.connection;
@@ -36,7 +36,7 @@ export class ConnectionsCreatePage implements OnInit, OnDestroy {
     const child = this.route.firstChild;
     if (child && child.snapshot) {
       const path = child.snapshot.url;
-      return path[ 0 ].path;
+      return path[0].path;
     } else {
       return undefined;
     }
@@ -78,7 +78,7 @@ export class ConnectionsCreatePage implements OnInit, OnDestroy {
   }
 
   cancel() {
-    this.router.navigate([ 'cancel' ], { relativeTo: this.route });
+    this.router.navigate(['cancel'], { relativeTo: this.route });
   }
 
   goBack() {
@@ -139,7 +139,7 @@ export class ConnectionsCreatePage implements OnInit, OnDestroy {
 
   doCreate() {
     this.current.events.emit({
-      kind: 'connection-trigger-create',
+      kind: 'connection-trigger-create'
     });
   }
 
@@ -148,17 +148,20 @@ export class ConnectionsCreatePage implements OnInit, OnDestroy {
     switch (event.kind) {
       case 'connection-set-connection':
         log.infoc(
-          () => 'Credentials: ' + JSON.stringify(this.current.credentials),
+          () => 'Credentials: ' + JSON.stringify(this.current.credentials)
         );
         log.infoc(() => 'hasCredentials: ' + this.current.hasCredentials());
         if (!this.current.hasConnector() && page !== 'connection-basics') {
           setTimeout(() => {
-            this.router.navigate([ 'connection-basics' ], {
-              relativeTo: this.route,
+            this.router.navigate(['connection-basics'], {
+              relativeTo: this.route
             });
           }, 10);
           return;
-        } else if (this.current.hasConnector() && page === 'connection-basics') {
+        } else if (
+          this.current.hasConnector() &&
+          page === 'connection-basics'
+        ) {
           this.goForward();
         }
         if (

--- a/src/app/connections/create-page/current-connection.ts
+++ b/src/app/connections/create-page/current-connection.ts
@@ -27,8 +27,8 @@ export class CurrentConnectionService {
 
   constructor(
     private store: ConnectionStore,
-    private connectorStore: ConnectorStore,
-  ) { }
+    private connectorStore: ConnectorStore
+  ) {}
 
   init() {
     this._credentials = undefined;
@@ -36,7 +36,7 @@ export class CurrentConnectionService {
     this._connection = undefined;
     this._loaded = false;
     this.subscription = this.events.subscribe((event: ConnectionEvent) =>
-      this.handleEvent(event),
+      this.handleEvent(event)
     );
   }
 
@@ -53,7 +53,7 @@ export class CurrentConnectionService {
         if (!this.fetchConnector(this._connection.connectorId)) {
           this.events.emit({
             kind: 'connection-check-credentials',
-            connectorId: this._connection.connectorId,
+            connectorId: this._connection.connectorId
           });
         }
         break;
@@ -61,7 +61,7 @@ export class CurrentConnectionService {
         if (!this.checkCredentials()) {
           this.events.emit({
             kind: 'connection-set-connection',
-            connection: this._connection,
+            connection: this._connection
           });
         }
         break;
@@ -140,7 +140,7 @@ export class CurrentConnectionService {
     const connectorId = connection.connectorId;
     this.events.emit({
       kind: 'connection-check-connector',
-      connection: this._connection,
+      connection: this._connection
     });
   }
 
@@ -156,21 +156,21 @@ export class CurrentConnectionService {
           sub.unsubscribe();
           this.events.emit({
             kind: 'connection-set-connection',
-            connection: this._connection,
+            connection: this._connection
           });
         },
         error => {
           log.infoc(
             () =>
               'Failed to fetch connector credentials: ' + JSON.stringify(error),
-            category,
+            category
           );
           sub.unsubscribe();
           this.events.emit({
             kind: 'connection-set-connection',
-            connection: this._connection,
+            connection: this._connection
           });
-        },
+        }
       );
       return true;
     } else {
@@ -189,7 +189,7 @@ export class CurrentConnectionService {
           this._connection.icon = connector.icon;
           this.events.emit({
             kind: 'connection-check-credentials',
-            connection: this._connection,
+            connection: this._connection
           });
           sub.unsubscribe();
         },
@@ -197,7 +197,7 @@ export class CurrentConnectionService {
           try {
             log.infoc(
               () => 'Failed to fetch connector: ' + JSON.stringify(error),
-              category,
+              category
             );
           } catch (err) {
             log.infoc(() => 'Failed to fetch connector: ' + error, category);
@@ -205,10 +205,10 @@ export class CurrentConnectionService {
           this.events.emit({
             kind: 'connection-check-credentials',
             error: error,
-            connection: this._connection,
+            connection: this._connection
           });
           sub.unsubscribe();
-        },
+        }
       );
       return true;
     }
@@ -234,7 +234,7 @@ export class CurrentConnectionService {
   private saveConnection(event: ConnectionEvent) {
     // poor man's clone
     const connection = <Connection>JSON.parse(
-      JSON.stringify(event['connection'] || this.connection),
+      JSON.stringify(event['connection'] || this.connection)
     );
     // just in case this leaks through from the form
     for (const prop in connection.connector.properties) {
@@ -256,7 +256,7 @@ export class CurrentConnectionService {
       (c: Connection) => {
         log.debugc(
           () => 'Saved connection: ' + JSON.stringify(c, undefined, 2),
-          category,
+          category
         );
         const action = event['action'];
         if (action && typeof action === 'function') {
@@ -268,14 +268,14 @@ export class CurrentConnectionService {
         log.debugc(
           () =>
             'Error saving connection: ' + JSON.stringify(reason, undefined, 2),
-          category,
+          category
         );
         const errorAction = event['error'];
         if (errorAction && typeof errorAction === 'function') {
           errorAction(reason);
         }
         sub.unsubscribe();
-      },
+      }
     );
   }
 }

--- a/src/app/connections/create-page/review/review.component.spec.ts
+++ b/src/app/connections/create-page/review/review.component.spec.ts
@@ -4,7 +4,6 @@ import { ConnectionsReviewComponent } from './review.component';
 import { CurrentConnectionService } from '../current-connection';
 
 describe('ConnectionsReviewComponent', () => {
-
   let current;
   let modalService;
   const connectionService = null;
@@ -17,11 +16,17 @@ describe('ConnectionsReviewComponent', () => {
     current = <CurrentConnectionService>{};
     modalService = jasmine.createSpyObj('modalService', ['show']);
     nextState = <RouterStateSnapshot>{};
-    component = new ConnectionsReviewComponent(current, modalService, connectionService, detector, router);
+    component = new ConnectionsReviewComponent(
+      current,
+      modalService,
+      connectionService,
+      detector,
+      router
+    );
   });
 
   describe('createReviewForm', () => {
-    it ('should return expected formGroup', () => {
+    it('should return expected formGroup', () => {
       const formGroup: FormGroup = component.createReviewForm();
       expect(formGroup.get('name')).toBeDefined();
       expect(formGroup.get('name').hasError('required')).toBe(true);
@@ -50,21 +55,18 @@ describe('ConnectionsReviewComponent', () => {
 
     it('should return true when user confirms he wants to leave wizard', done => {
       modalService.show.and.returnValue(Promise.resolve({ result: true }));
-      component.canDeactivate(nextState)
-        .then(canDeactivate => {
-          expect(canDeactivate).toBe(true);
-          done();
-        });
+      component.canDeactivate(nextState).then(canDeactivate => {
+        expect(canDeactivate).toBe(true);
+        done();
+      });
     });
 
     it('should return false when user does not confirm he wants to leave wizard', done => {
       modalService.show.and.returnValue(Promise.resolve({ result: false }));
-      component.canDeactivate(nextState)
-        .then(canDeactivate => {
-          expect(canDeactivate).toBe(false);
-          done();
-        });
+      component.canDeactivate(nextState).then(canDeactivate => {
+        expect(canDeactivate).toBe(false);
+        done();
+      });
     });
   });
-
 });

--- a/src/app/connections/create-page/review/review.component.ts
+++ b/src/app/connections/create-page/review/review.component.ts
@@ -14,9 +14,10 @@ const category = getCategory('Connections');
 
 @Component({
   selector: 'syndesis-connections-review',
-  templateUrl: 'review.component.html',
+  templateUrl: 'review.component.html'
 })
-export class ConnectionsReviewComponent implements CanComponentDeactivate, OnInit, OnDestroy {
+export class ConnectionsReviewComponent
+  implements CanComponentDeactivate, OnInit, OnDestroy {
   saved = false;
   reviewForm: FormGroup;
   sub: Subscription = undefined;
@@ -26,7 +27,7 @@ export class ConnectionsReviewComponent implements CanComponentDeactivate, OnIni
     private modalService: ModalService,
     private connectionService: ConnectionService,
     private detector: ChangeDetectorRef,
-    private router: Router,
+    private router: Router
   ) {
     this.reviewForm = this.createReviewForm();
   }
@@ -34,7 +35,7 @@ export class ConnectionsReviewComponent implements CanComponentDeactivate, OnIni
   createReviewForm(): FormGroup {
     return new FormGroup({
       name: new FormControl(null, Validators.required),
-      description: new FormControl(),
+      description: new FormControl()
     });
   }
 
@@ -42,7 +43,7 @@ export class ConnectionsReviewComponent implements CanComponentDeactivate, OnIni
     const control = this.reviewForm.get('name');
     if (!control.hasError('required')) {
       const validationErrors = await this.connectionService.validateName(
-        control.value,
+        control.value
       );
       control.setErrors(validationErrors);
       this.detector.markForCheck();
@@ -59,7 +60,7 @@ export class ConnectionsReviewComponent implements CanComponentDeactivate, OnIni
     } else {
       this.current.connection.name = this.reviewForm.get('name').value;
       this.current.connection.description = this.reviewForm.get(
-        'description',
+        'description'
       ).value;
       this.saved = true;
       this.current.events.emit({
@@ -73,9 +74,9 @@ export class ConnectionsReviewComponent implements CanComponentDeactivate, OnIni
             () =>
               'Error creating connection: ' +
               JSON.stringify(reason, undefined, 2),
-            category,
+            category
           );
-        },
+        }
       });
     }
   }

--- a/src/app/connections/detail-page/breadcrumb.component.ts
+++ b/src/app/connections/detail-page/breadcrumb.component.ts
@@ -18,7 +18,8 @@ import { Connection } from '../../model';
       </div>
     </div>
   `,
-  styles: [`
+  styles: [
+    `
     .toolbar-pf {
       background: inherit;
     }
@@ -26,6 +27,7 @@ import { Connection } from '../../model';
       display: inline-block;
       margin-bottom: 6px;
     }
-  `],
+  `
+  ]
 })
 export class ConnectionDetailBreadcrumbComponent {}

--- a/src/app/connections/detail-page/configuration.component.ts
+++ b/src/app/connections/detail-page/configuration.component.ts
@@ -1,16 +1,25 @@
-import { Component, EventEmitter, Input, Output, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  OnChanges,
+  SimpleChanges
+} from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { DynamicFormControlModel, DynamicFormService } from '@ng-dynamic-forms/core';
+import {
+  DynamicFormControlModel,
+  DynamicFormService
+} from '@ng-dynamic-forms/core';
 
 import { Connection } from '../../model';
 import { ConnectionConfigurationService } from '../common/configuration/configuration.service';
 
 @Component({
   selector: 'syndesis-connection-detail-configuration',
-  templateUrl: './configuration.component.html',
+  templateUrl: './configuration.component.html'
 })
 export class ConnectionDetailConfigurationComponent implements OnChanges {
-
   @Input() connection: Connection;
   @Output() updated = new EventEmitter<Connection>();
   mode: 'view' | 'edit' = 'view';
@@ -19,8 +28,8 @@ export class ConnectionDetailConfigurationComponent implements OnChanges {
 
   constructor(
     private configurationService: ConnectionConfigurationService,
-    private formService: DynamicFormService,
-  ) { }
+    private formService: DynamicFormService
+  ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     this.resetView(true);
@@ -38,13 +47,18 @@ export class ConnectionDetailConfigurationComponent implements OnChanges {
 
   save() {
     this.mode = 'view';
-    this.connection.configuredProperties = this.configurationService.sanitize(this.formGroup.value);
+    this.connection.configuredProperties = this.configurationService.sanitize(
+      this.formGroup.value
+    );
     this.updated.emit(this.connection);
     this.resetView(true);
   }
 
   resetView(readOnly: boolean) {
-    this.formModel = this.configurationService.getFormModel(this.connection, readOnly);
+    this.formModel = this.configurationService.getFormModel(
+      this.connection,
+      readOnly
+    );
     this.formGroup = this.formService.createFormGroup(this.formModel);
   }
 }

--- a/src/app/connections/detail-page/detail-page.component.ts
+++ b/src/app/connections/detail-page/detail-page.component.ts
@@ -22,7 +22,8 @@ import { ConnectionStore } from '../../store/connection/connection.store';
       </ng-container>
     </syndesis-loading>
   `,
-  styles: [`
+  styles: [
+    `
   :host {
     display: flex;
     flex-direction: column;
@@ -43,7 +44,8 @@ import { ConnectionStore } from '../../store/connection/connection.store';
     padding-bottom: 20px;
   }
 
-`],
+`
+  ]
 })
 export class ConnectionDetailPageComponent implements OnInit, OnDestroy {
   connection: Connection;
@@ -53,7 +55,7 @@ export class ConnectionDetailPageComponent implements OnInit, OnDestroy {
 
   constructor(
     private connectionStore: ConnectionStore,
-    private route: ActivatedRoute,
+    private route: ActivatedRoute
   ) {
     this.loading = connectionStore.loading;
   }
@@ -61,9 +63,11 @@ export class ConnectionDetailPageComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.route.paramMap.subscribe(params => {
       const id = params.get('id');
-      this.subscription = this.connectionStore.load(id).subscribe(connection => {
-        this.connection = connection;
-      });
+      this.subscription = this.connectionStore
+        .load(id)
+        .subscribe(connection => {
+          this.connection = connection;
+        });
     });
   }
 
@@ -75,5 +79,4 @@ export class ConnectionDetailPageComponent implements OnInit, OnDestroy {
     this.connection = connection;
     this.connectionStore.update(connection);
   }
-
 }

--- a/src/app/connections/detail-page/info.component.ts
+++ b/src/app/connections/detail-page/info.component.ts
@@ -41,22 +41,23 @@ import { ConnectionConfigurationService } from '../common/configuration/configur
       </dd>
     </dl>
   `,
-  styles: [`
+  styles: [
+    `
     h1 dt { width: 46px; }
     h1 dd { margin-left: 66px; }
     dt { text-align: left; width: 120px; }
     dd { margin-left: 140px; }
     dt:not(:first-child), dd:not(:first-child) { margin-top: 10px; }
-  `],
+  `
+  ]
 })
 export class ConnectionDetailInfoComponent {
-
   @Input() connection: Connection;
   @Output() updated = new EventEmitter<Connection>();
 
   constructor(
     private connectionService: ConnectionService,
-    private configurationService: ConnectionConfigurationService,
+    private configurationService: ConnectionConfigurationService
   ) {}
 
   onAttributeUpdated(attr: string, value) {
@@ -68,7 +69,8 @@ export class ConnectionDetailInfoComponent {
     if (name === '') {
       return 'Name is required';
     } else if (name !== this.connection.name) {
-      return this.connectionService.validateName(name)
+      return this.connectionService
+        .validateName(name)
         .then(validationErrors => {
           if (validationErrors && validationErrors.UniqueProperty) {
             return 'That name is taken. Try another.';
@@ -77,6 +79,5 @@ export class ConnectionDetailInfoComponent {
           }
         });
     }
-  }
-
+  };
 }

--- a/src/app/connections/detail-page/info.component.ts
+++ b/src/app/connections/detail-page/info.component.ts
@@ -65,6 +65,7 @@ export class ConnectionDetailInfoComponent {
     this.updated.emit(this.connection);
   }
 
+  /* tslint:disable semicolon */
   validateName = (name: string) => {
     if (name === '') {
       return 'Name is required';
@@ -80,4 +81,5 @@ export class ConnectionDetailInfoComponent {
         });
     }
   };
+  /* tslint:enable semicolon */
 }

--- a/src/app/connections/list-page/list-page.component.ts
+++ b/src/app/connections/list-page/list-page.component.ts
@@ -13,12 +13,14 @@ const category = getCategory('Connections');
 @Component({
   selector: 'syndesis-connections-list-page',
   templateUrl: './list-page.component.html',
-  styleUrls: ['./list-page.component.scss'],
+  styleUrls: ['./list-page.component.scss']
 })
 export class ConnectionsListPage implements OnInit {
   loading: Observable<boolean>;
   connections: Observable<Connections>;
-  filteredConnections: Subject<Connections> = new BehaviorSubject(<Connections>{});
+  filteredConnections: Subject<
+    Connections
+  > = new BehaviorSubject(<Connections>{});
 
   constructor(private store: ConnectionStore, private router: Router) {
     this.loading = store.loading;

--- a/src/app/connections/list/list.component.scss
+++ b/src/app/connections/list/list.component.scss
@@ -3,7 +3,6 @@
 .connections-list {
   .cards {
     .card {
-
       &.new-connection {
         .card-pf-view {
           background: inherit;

--- a/src/app/connections/list/list.component.spec.ts
+++ b/src/app/connections/list/list.component.spec.ts
@@ -27,11 +27,11 @@ describe('ConnectionsListComponent', () => {
           ModalModule.forRoot(),
           BsDropdownModule.forRoot(),
           StoreModule,
-          NotificationModule,
+          NotificationModule
         ],
-        declarations: [ConnectionsListComponent],
+        declarations: [ConnectionsListComponent]
       }).compileComponents();
-    }),
+    })
   );
 
   beforeEach(() => {

--- a/src/app/connections/list/list.component.ts
+++ b/src/app/connections/list/list.component.ts
@@ -5,7 +5,7 @@ import {
   OnInit,
   EventEmitter,
   ViewChild,
-  ChangeDetectorRef,
+  ChangeDetectorRef
 } from '@angular/core';
 
 import { NotificationService, NotificationType } from 'patternfly-ng';
@@ -20,7 +20,7 @@ const category = getCategory('Connections');
 @Component({
   selector: 'syndesis-connections-list',
   templateUrl: './list.component.html',
-  styleUrls: ['./list.component.scss'],
+  styleUrls: ['./list.component.scss']
 })
 export class ConnectionsListComponent implements OnInit {
   truncateTrail = '…';
@@ -38,7 +38,7 @@ export class ConnectionsListComponent implements OnInit {
     public store: ConnectionStore,
     public detector: ChangeDetectorRef,
     private notificationService: NotificationService,
-    private modalService: ModalService,
+    private modalService: ModalService
   ) {}
 
   //-----  Delete ------------------->>
@@ -53,7 +53,7 @@ export class ConnectionsListComponent implements OnInit {
             type: NotificationType.SUCCESS,
             header: 'Delete Successful',
             message: 'Connection successfully deleted.',
-            showClose: true,
+            showClose: true
           });
         }, 10);
       },
@@ -64,10 +64,10 @@ export class ConnectionsListComponent implements OnInit {
             type: NotificationType.DANGER,
             header: 'Delete Failed',
             message: `Failed to delete connection: ${err}`,
-            showClose: true,
+            showClose: true
           });
         }, 10);
-      },
+      }
     );
   }
 
@@ -85,7 +85,7 @@ export class ConnectionsListComponent implements OnInit {
     if (connection) {
       log.debugc(
         () => 'Selected connection (list): ' + connection.name,
-        category,
+        category
       );
       this.selectedId = connection.id;
     }
@@ -102,7 +102,7 @@ export class ConnectionsListComponent implements OnInit {
     log.debugc(
       () =>
         'Got connections: ' + JSON.stringify(this.connections, undefined, 2),
-      category,
+      category
     );
   }
 
@@ -115,7 +115,7 @@ export class ConnectionsListComponent implements OnInit {
       notification.message,
       false,
       null,
-      [],
+      []
     );
   }
 }

--- a/src/app/dashboard/connections.component.ts
+++ b/src/app/dashboard/connections.component.ts
@@ -4,7 +4,7 @@ import {
   Input,
   OnInit,
   Output,
-  ViewChild,
+  ViewChild
 } from '@angular/core';
 
 import { log, getCategory } from '../logging';
@@ -17,7 +17,7 @@ const category = getCategory('Dashboard');
 @Component({
   selector: 'syndesis-dashboard-connections',
   templateUrl: './connections.component.html',
-  styleUrls: ['./connections.component.scss'],
+  styleUrls: ['./connections.component.scss']
 })
 export class DashboardConnectionsComponent implements OnInit {
   selectedId = undefined;
@@ -33,7 +33,7 @@ export class DashboardConnectionsComponent implements OnInit {
   onSelect(connection: Connection) {
     log.debugc(
       () => 'Selected connection (list): ' + connection.name,
-      category,
+      category
     );
     this.selectedId = connection.id;
     this.selectedConnection.emit(connection);
@@ -45,7 +45,7 @@ export class DashboardConnectionsComponent implements OnInit {
     log.debugc(
       () =>
         'Got connections: ' + JSON.stringify(this.connections, undefined, 2),
-      category,
+      category
     );
   }
 }

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -39,13 +39,13 @@ describe('DashboardComponent', () => {
           RouterTestingModule.withRoutes([]),
           RestangularModule.forRoot(),
           NotificationModule,
-          IntegrationsListModule,
+          IntegrationsListModule
         ],
         declarations: [
           DashboardComponent,
           EmptyStateComponent,
           DashboardConnectionsComponent,
-          DashboardIntegrationsComponent,
+          DashboardIntegrationsComponent
         ],
         providers: [
           MockBackend,
@@ -55,12 +55,12 @@ describe('DashboardComponent', () => {
             useFactory: (backend, options) => {
               return new Http(backend, options);
             },
-            deps: [MockBackend, RequestOptions],
+            deps: [MockBackend, RequestOptions]
           },
-          TourService,
-        ],
+          TourService
+        ]
       }).compileComponents();
-    }),
+    })
   );
 
   beforeEach(() => {

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -13,7 +13,7 @@ const category = getCategory('Dashboard');
 
 @Component({
   selector: 'syndesis-dashboard',
-  templateUrl: './dashboard.component.html',
+  templateUrl: './dashboard.component.html'
 })
 export class DashboardComponent implements OnInit {
   connections: Observable<Connections>;
@@ -24,10 +24,12 @@ export class DashboardComponent implements OnInit {
   truncateLimit = 80;
   truncateTrail = '…';
 
-  constructor(private connectionStore: ConnectionStore,
-              private integrationStore: IntegrationStore,
-              public tourService: TourService,
-              private userService: UserService) {
+  constructor(
+    private connectionStore: ConnectionStore,
+    private integrationStore: IntegrationStore,
+    public tourService: TourService,
+    private userService: UserService
+  ) {
     this.connections = this.connectionStore.list;
     this.integrations = this.integrationStore.list;
     this.connectionsLoading = this.connectionStore.loading;
@@ -41,14 +43,19 @@ export class DashboardComponent implements OnInit {
      * If guided tour state is set to be shown (i.e. true), then show it for this page, otherwise don't.
      */
     if (this.userService.getTourState() === true) {
-      this.tourService.initialize([ {
-          anchorId: 'dashboard.navigation',
-          content: 'View integrations, connections or settings for applications that Fuse Ignite is registered with.',
-          placement: 'right',
-          title: 'Navigation',
-        } ], {
-          route: 'dashboard',
-        },
+      this.tourService.initialize(
+        [
+          {
+            anchorId: 'dashboard.navigation',
+            content:
+              'View integrations, connections or settings for applications that Fuse Ignite is registered with.',
+            placement: 'right',
+            title: 'Navigation'
+          }
+        ],
+        {
+          route: 'dashboard'
+        }
       );
       setTimeout(() => this.tourService.start());
     }

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -20,7 +20,7 @@ import { DashboardConnectionsComponent } from './connections.component';
 import { DashboardIntegrationsComponent } from './integrations.component';
 
 const routes: Routes = [
-  { path: '', component: DashboardComponent, pathMatch: 'full' },
+  { path: '', component: DashboardComponent, pathMatch: 'full' }
 ];
 
 @NgModule({
@@ -33,14 +33,14 @@ const routes: Routes = [
     ChartsModule,
     ModalModule,
     TooltipModule,
-    BsDropdownModule,
+    BsDropdownModule
   ],
   declarations: [
     DashboardComponent,
     DashboardConnectionsComponent,
     DashboardIntegrationsComponent,
     EmptyStateComponent,
-    PopularTemplatesComponent,
-  ],
+    PopularTemplatesComponent
+  ]
 })
 export class DashboardModule {}

--- a/src/app/dashboard/emptystate.component.ts
+++ b/src/app/dashboard/emptystate.component.ts
@@ -14,7 +14,7 @@ const category = getCategory('Dashboard');
 @Component({
   selector: 'syndesis-dashboard-empty-state',
   templateUrl: './emptystate.component.html',
-  styleUrls: [ './emptystate.component.scss' ],
+  styleUrls: ['./emptystate.component.scss']
 })
 export class EmptyStateComponent implements OnInit {
   connections: Observable<Connections>;
@@ -23,15 +23,17 @@ export class EmptyStateComponent implements OnInit {
   truncateLimit = 80;
   truncateTrail = '…';
 
-  constructor(private connectionStore: ConnectionStore,
-              private router: Router,
-              public tourService: TourService,
-              private userService: UserService) {
+  constructor(
+    private connectionStore: ConnectionStore,
+    private router: Router,
+    public tourService: TourService,
+    private userService: UserService
+  ) {
     this.connections = this.connectionStore.list;
   }
 
   selectedConnection(connection: Connection) {
-    this.router.navigate([ '/connections', connection.id ]);
+    this.router.navigate(['/connections', connection.id]);
   }
 
   ngOnInit() {
@@ -40,13 +42,15 @@ export class EmptyStateComponent implements OnInit {
      * If guided tour state is set to be shown (i.e. true), then show it for this page, otherwise don't.
      */
     if (this.userService.getTourState() === true) {
-      this.tourService.initialize([ {
+      this.tourService.initialize([
+        {
           anchorId: 'dashboard.integration',
           content: 'Create Integration',
           placement: 'bottom',
-          title: 'After creating at least two connections, you can create an integration.',
-        } ],
-      );
+          title:
+            'After creating at least two connections, you can create an integration.'
+        }
+      ]);
       setTimeout(() => this.tourService.start());
     }
   }

--- a/src/app/dashboard/integrations.component.scss
+++ b/src/app/dashboard/integrations.component.scss
@@ -43,8 +43,8 @@
       margin: 0;
     }
 
-    [class^="col-"],
-    [class*=" col-"] {
+    [class^='col-'],
+    [class*=' col-'] {
       padding: 0;
 
       h1 {

--- a/src/app/dashboard/integrations.component.ts
+++ b/src/app/dashboard/integrations.component.ts
@@ -57,7 +57,6 @@ export class DashboardIntegrationsComponent {
     const draft = [];
     const inactive = [];
     let total = 0;
-
     (this.integrations || []).forEach(function(a) {
       /* TODO - too noisy
       log.debugc(() => 'Integration: ' + JSON.stringify(a));

--- a/src/app/dashboard/integrations.component.ts
+++ b/src/app/dashboard/integrations.component.ts
@@ -13,10 +13,9 @@ const category = getCategory('Dashboard');
 @Component({
   selector: 'syndesis-dashboard-integrations',
   templateUrl: './integrations.component.html',
-  styleUrls: ['./integrations.component.scss'],
+  styleUrls: ['./integrations.component.scss']
 })
 export class DashboardIntegrationsComponent {
-
   @Input() integrations: Integrations;
   @Input() connections: Connections;
   @Input() integrationsLoading: boolean;
@@ -30,7 +29,7 @@ export class DashboardIntegrationsComponent {
     return [
       this.countActiveIntegrations(),
       this.countDraftIntegrations(),
-      this.countInactiveIntegrations(),
+      this.countInactiveIntegrations()
     ];
   }
 
@@ -41,20 +40,15 @@ export class DashboardIntegrationsComponent {
       backgroundColor: [
         '#0088CE', // PatternFly Blue 400, Active
         '#EC7A08', // PatternFly Orange 400, Draft
-        '#D1D1D1', // PatternFly Black 300, Inactive
-      ],
-    },
+        '#D1D1D1' // PatternFly Black 300, Inactive
+      ]
+    }
   ];
   doughnutChartOptions: any = {
-    cutoutPercentage: 75,
+    cutoutPercentage: 75
   };
 
-  constructor(
-    public route: ActivatedRoute,
-    private router: Router,
-  ) {
-
-  }
+  constructor(public route: ActivatedRoute, private router: Router) {}
 
   //-----  Integration Board Chart ------------------->>
 
@@ -92,7 +86,7 @@ export class DashboardIntegrationsComponent {
       active: active,
       draft: draft,
       inactive: inactive,
-      total: total,
+      total: total
     };
   }
 
@@ -158,7 +152,7 @@ export class DashboardIntegrationsComponent {
   goto(integration: Integration) {
     this.router.navigate(
       ['/integrations/edit', integration.id, 'save-or-add-step'],
-      { relativeTo: this.route },
+      { relativeTo: this.route }
     );
   }
 

--- a/src/app/dashboard/populartemplates.component.ts
+++ b/src/app/dashboard/populartemplates.component.ts
@@ -4,7 +4,7 @@ import { IntegrationTemplates } from '../model';
 
 @Component({
   selector: 'syndesis-popular-templates',
-  templateUrl: './populartemplates.component.html',
+  templateUrl: './populartemplates.component.html'
 })
 export class PopularTemplatesComponent {
   @Input() templates: IntegrationTemplates;

--- a/src/app/integrations/components/integrationViewBase.component.ts
+++ b/src/app/integrations/components/integrationViewBase.component.ts
@@ -12,7 +12,7 @@ import {
   ListEvent,
   Notification,
   NotificationService,
-  NotificationType,
+  NotificationType
 } from 'patternfly-ng';
 
 export class IntegrationViewBase {
@@ -25,11 +25,12 @@ export class IntegrationViewBase {
     public router: Router,
     public notificationService: NotificationService,
     public modalService: ModalService,
-    public application: ApplicationRef,
+    public application: ApplicationRef
   ) {}
 
   canEdit = int => int.currentStatus !== 'Deleted';
-  canActivate = int => int.currentStatus === 'Deactivated' || int.currentStatus === 'Draft';
+  canActivate = int =>
+    int.currentStatus === 'Deactivated' || int.currentStatus === 'Draft';
   canDeactivate = int => int.currentStatus === 'Activated';
   canDelete = int => int.currentStatus !== 'Deleted';
 
@@ -44,14 +45,16 @@ export class IntegrationViewBase {
         return this.router.navigate(['/integrations', integration.id, 'edit']);
       case 'activate':
         header = 'Integration is activating';
-        message = 'Please allow a moment for the integration to fully activate.';
+        message =
+          'Please allow a moment for the integration to fully activate.';
         danger = 'Failed to activate integration';
         reason = 'Error activating integration';
         request = this.requestActivate(integration);
         break;
       case 'deactivate':
         header = 'Integration is deactivating';
-        message = 'Please allow a moment for the integration to be deactivated.';
+        message =
+          'Please allow a moment for the integration to be deactivated.';
         danger = 'Failed to deactivate integration';
         reason = 'Error deactivating integration';
         request = this.requestDeactivate(integration);
@@ -66,20 +69,27 @@ export class IntegrationViewBase {
       default:
         break;
     }
-    return request.then(modal => modal.result
-      ? this.doAction(action, integration)
-          .then(_ => this.popNotification({
-            type: NotificationType.SUCCESS,
-            header,
-            message,
-          }))
-          .catch(error => this.popNotification({
-              type: NotificationType.DANGER,
-              header: danger,
-              message: `${reason}: ${error}`,
-            }))
-          .then(_ => this.application.tick())
-      : false);
+    return request.then(
+      modal =>
+        modal.result
+          ? this.doAction(action, integration)
+              .then(_ =>
+                this.popNotification({
+                  type: NotificationType.SUCCESS,
+                  header,
+                  message
+                })
+              )
+              .catch(error =>
+                this.popNotification({
+                  type: NotificationType.DANGER,
+                  header: danger,
+                  message: `${reason}: ${error}`
+                })
+              )
+              .then(_ => this.application.tick())
+          : false
+    );
   }
 
   doAction(action: string, integration: Integration) {
@@ -103,7 +113,7 @@ export class IntegrationViewBase {
     log.debugc(
       () =>
         'Selected integration for activation: ' +
-        JSON.stringify(integration['id']),
+        JSON.stringify(integration['id'])
     );
     this.selectedIntegration = integration;
     return this.showModal('activate');
@@ -114,7 +124,7 @@ export class IntegrationViewBase {
     log.debugc(
       () =>
         'Selected integration for deactivation: ' +
-        JSON.stringify(integration['id']),
+        JSON.stringify(integration['id'])
     );
     this.selectedIntegration = integration;
     return this.showModal('deactivate');
@@ -124,7 +134,7 @@ export class IntegrationViewBase {
   requestDelete(integration: Integration) {
     log.debugc(
       () =>
-        'Selected integration for delete: ' + JSON.stringify(integration['id']),
+        'Selected integration for delete: ' + JSON.stringify(integration['id'])
     );
     this.selectedIntegration = integration;
     return this.showModal('delete');
@@ -136,9 +146,12 @@ export class IntegrationViewBase {
     log.debugc(
       () =>
         'Selected integration for activation: ' +
-        JSON.stringify(integration['id']),
+        JSON.stringify(integration['id'])
     );
-    return this.store.activate(integration).take(1).toPromise();
+    return this.store
+      .activate(integration)
+      .take(1)
+      .toPromise();
   }
 
   // Actual activate/deactivate action once the user confirms
@@ -146,18 +159,24 @@ export class IntegrationViewBase {
     log.debugc(
       () =>
         'Selected integration for deactivation: ' +
-        JSON.stringify(integration['id']),
+        JSON.stringify(integration['id'])
     );
-    return this.store.deactivate(integration).take(1).toPromise();
+    return this.store
+      .deactivate(integration)
+      .take(1)
+      .toPromise();
   }
 
   // Actual delete action once the user confirms
   deleteAction(integration: Integration): Promise<any> {
     log.debugc(
       () =>
-        'Selected integration for delete: ' + JSON.stringify(integration['id']),
+        'Selected integration for delete: ' + JSON.stringify(integration['id'])
     );
-    return this.store.delete(integration).take(1).toPromise();
+    return this.store
+      .delete(integration)
+      .take(1)
+      .toPromise();
   }
 
   //-----  Icons ------------------->>
@@ -202,7 +221,7 @@ export class IntegrationViewBase {
       notification.message,
       false,
       null,
-      [],
+      []
     );
   }
 }

--- a/src/app/integrations/components/integrationViewBase.component.ts
+++ b/src/app/integrations/components/integrationViewBase.component.ts
@@ -1,16 +1,11 @@
-import { ApplicationRef, Input, ViewChild } from '@angular/core';
+import { ApplicationRef } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Subscription } from 'rxjs/Subscription';
-import { Integrations, Integration } from '../../model';
+import { Integration } from '../../model';
 import { IntegrationStore } from '../../store/integration/integration.store';
 import { ModalService } from '../../common/modal/modal.service';
-import { log, getCategory } from '../../logging';
+import { log } from '../../logging';
 
 import {
-  Action,
-  ActionConfig,
-  ListEvent,
-  Notification,
   NotificationService,
   NotificationType
 } from 'patternfly-ng';

--- a/src/app/integrations/components/integrationViewBase.component.ts
+++ b/src/app/integrations/components/integrationViewBase.component.ts
@@ -29,8 +29,10 @@ export class IntegrationViewBase {
   ) {}
 
   canEdit = int => int.currentStatus !== 'Deleted';
+  /* tslint:disable semicolon */
   canActivate = int =>
     int.currentStatus === 'Deactivated' || int.currentStatus === 'Draft';
+  /* tslint:enable semicolon */
   canDeactivate = int => int.currentStatus === 'Activated';
   canDelete = int => int.currentStatus !== 'Deleted';
 

--- a/src/app/integrations/components/status.component.scss
+++ b/src/app/integrations/components/status.component.scss
@@ -1,13 +1,13 @@
 @import 'patternfly-sass/assets/stylesheets/patternfly/color-variables';
 
 .syndesis-integration-status {
-    display: inline-block;
-    .not-pending {
-        .label {
-            &.label-inactive {
-                background: $color-pf-black-300;
-                color: #000000;
-            }
-        }
+  display: inline-block;
+  .not-pending {
+    .label {
+      &.label-inactive {
+        background: $color-pf-black-300;
+        color: #000000;
+      }
     }
+  }
 }

--- a/src/app/integrations/components/status.component.ts
+++ b/src/app/integrations/components/status.component.ts
@@ -20,13 +20,13 @@ import { Integration } from '../../model';
       </div>
     </div>
   `,
-  styleUrls: ['./status.component.scss'],
+  styleUrls: ['./status.component.scss']
 })
 export class IntegrationStatusComponent {
   @Input() integration: Integration;
 
   //-----  Get Status Icon Class ------------------->>
-  getLabelClass(currentStatus): string|any {
+  getLabelClass(currentStatus): string | any {
     switch (currentStatus) {
       case 'Activated':
         return 'primary';
@@ -41,7 +41,7 @@ export class IntegrationStatusComponent {
     }
   }
 
-  getStatusText(currentStatus): string|any {
+  getStatusText(currentStatus): string | any {
     switch (currentStatus) {
       case 'Activated':
         return 'Active';

--- a/src/app/integrations/detail-page/detail.component.ts
+++ b/src/app/integrations/detail-page/detail.component.ts
@@ -3,7 +3,7 @@ import {
   Component,
   OnInit,
   OnDestroy,
-  ChangeDetectorRef,
+  ChangeDetectorRef
 } from '@angular/core';
 
 import { ActivatedRoute, Params, Router, UrlSegment } from '@angular/router';
@@ -22,7 +22,7 @@ import { saveAs } from 'file-saver';
 @Component({
   selector: 'syndesis-integration-detail-page',
   templateUrl: 'detail.component.html',
-  styleUrls: ['detail.component.scss'],
+  styleUrls: ['detail.component.scss']
 })
 export class IntegrationsDetailComponent extends IntegrationViewBase
   implements OnInit, OnDestroy {
@@ -41,9 +41,9 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
       status: undefined,
       actions: [
         {
-          label: 'Edit Draft',
-        },
-      ],
+          label: 'Edit Draft'
+        }
+      ]
     },
     {
       version: 'V. 1.4',
@@ -54,19 +54,19 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
         {
           icon: 'pf-icon pficon-ok',
           class: '',
-          label: 'Success',
+          label: 'Success'
         },
         {
           icon: undefined,
           class: 'label label-info pull-right',
-          label: 'Running',
-        },
+          label: 'Running'
+        }
       ],
       actions: [
         {
-          label: 'Duplicate',
-        },
-      ],
+          label: 'Duplicate'
+        }
+      ]
     },
     {
       version: 'V. 1.3',
@@ -76,17 +76,17 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
       status: [
         {
           icon: 'pf-icon pficon-ok',
-          label: 'Success',
-        },
+          label: 'Success'
+        }
       ],
       actions: [
         {
-          label: 'Deploy',
+          label: 'Deploy'
         },
         {
-          label: 'Duplicate',
-        },
-      ],
+          label: 'Duplicate'
+        }
+      ]
     },
     {
       version: 'V. 1.2',
@@ -96,17 +96,17 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
       status: [
         {
           icon: 'pf-icon pficon-ok',
-          label: 'Success',
-        },
+          label: 'Success'
+        }
       ],
       actions: [
         {
-          label: 'Deploy',
+          label: 'Deploy'
         },
         {
-          label: 'Duplicate',
-        },
-      ],
+          label: 'Duplicate'
+        }
+      ]
     },
     {
       version: 'V. 1.1',
@@ -116,18 +116,18 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
       status: [
         {
           icon: 'pf-icon pficon-error-circle-o',
-          label: 'Failure',
-        },
+          label: 'Failure'
+        }
       ],
       actions: [
         {
-          label: 'Deploy',
+          label: 'Deploy'
         },
         {
-          label: 'Duplicate',
-        },
-      ],
-    },
+          label: 'Duplicate'
+        }
+      ]
+    }
   ];
 
   constructor(
@@ -139,7 +139,7 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
     public notificationService: NotificationService,
     public modalService: ModalService,
     public application: ApplicationRef,
-    private integrationSupportService: IntegrationSupportService,
+    private integrationSupportService: IntegrationSupportService
   ) {
     super(store, route, router, notificationService, modalService, application);
     this.integration = this.store.resource;
@@ -180,7 +180,7 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
           'Updated description',
           false,
           undefined,
-          undefined,
+          undefined
         );
       })
       .catch(reason => {
@@ -190,7 +190,7 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
           'Failed to update description: ' + reason,
           false,
           undefined,
-          undefined,
+          undefined
         );
       });
   }
@@ -207,7 +207,7 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
           'Updated ' + attr,
           false,
           undefined,
-          undefined,
+          undefined
         );
       })
       .catch(reason => {
@@ -217,7 +217,7 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
           'Failed to update ' + attr + ': ' + reason,
           false,
           undefined,
-          undefined,
+          undefined
         );
       });
   }
@@ -237,7 +237,7 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
     this.popNotification({
       type: NotificationType.INFO,
       header: 'Duplicating revision',
-      message: 'Duplicating revision ' + revision.version,
+      message: 'Duplicating revision ' + revision.version
     });
     const sub = this.store.create(integration).subscribe(
       created => {
@@ -249,12 +249,10 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
           type: NotificationType.DANGER,
           header: 'Failed to duplicate revision',
           message:
-            resp.length !== undefined
-              ? resp.data[0].message
-              : resp.data.message,
+            resp.length !== undefined ? resp.data[0].message : resp.data.message
         });
         sub.unsubscribe();
-      },
+      }
     );
   }
 
@@ -264,14 +262,14 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
     this.popNotification({
       type: NotificationType.INFO,
       header: 'Deploying revision',
-      message: 'Deploying revision ' + revision.version,
+      message: 'Deploying revision ' + revision.version
     });
     const sub = this.store.update(integration).subscribe(
       updated => {
         this.popNotification({
           type: NotificationType.SUCCESS,
           header: 'Deployment successful',
-          message: 'Deployed revision ' + revision.version,
+          message: 'Deployed revision ' + revision.version
         });
         sub.unsubscribe();
       },
@@ -280,12 +278,10 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
           type: NotificationType.DANGER,
           header: 'Failed to deploy revision',
           message:
-            resp.length !== undefined
-              ? resp.data[0].message
-              : resp.data.message,
+            resp.length !== undefined ? resp.data[0].message : resp.data.message
         });
         sub.unsubscribe();
-      },
+      }
     );
   }
 
@@ -323,7 +319,7 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
               const status = {
                 icon: undefined,
                 class: '',
-                label: '',
+                label: ''
               };
               // TODO this is kinda fake data
               switch (rev.currentState) {
@@ -333,8 +329,8 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
                 case 'Undeployed':
                   break;
                 case 'Active':
-                  (status.icon = 'pf-icon pficon-ok'), (status.label =
-                    'Success');
+                  (status.icon = 'pf-icon pficon-ok'),
+                    (status.label = 'Success');
                   break;
                 case 'Error':
                   status.icon = 'pf-icon pficon-error-circle-o';
@@ -358,7 +354,7 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
                     action: 'duplicate',
                   },
                   */
-                ],
+                ]
               };
               let isDeployed = false;
               if (row.version === i.deployedRevisionId) {
@@ -366,7 +362,7 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
                 const state = {
                   icon: undefined,
                   class: '',
-                  label: rev.currentState,
+                  label: rev.currentState
                 };
                 switch (rev.currentState) {
                   case 'Draft':
@@ -389,7 +385,7 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
               if (!isDeployed && rev.spec && rev.spec.steps) {
                 row.actions.push({
                   label: 'Deploy',
-                  action: 'deploy',
+                  action: 'deploy'
                 });
               }
               return row;
@@ -402,7 +398,7 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
             // @TODO: Remove this try/catch once ChangeDetection is restored
           }
         }, 50);
-      },
+      }
     );
     this.routeSubscription = this.route.params
       .pluck<Params, string>('integrationId')
@@ -417,8 +413,11 @@ export class IntegrationsDetailComponent extends IntegrationViewBase
 
   exportIntegration() {
     const id = this.i.id;
-    this.integrationSupportService.exportIntegration(this.i.id).toPromise().then(value => {
-      saveAs(value.blob(), id + '-export.zip');
-    });
+    this.integrationSupportService
+      .exportIntegration(this.i.id)
+      .toPromise()
+      .then(value => {
+        saveAs(value.blob(), id + '-export.zip');
+      });
   }
 }

--- a/src/app/integrations/edit-page/action-configure/action-configure.component.scss
+++ b/src/app/integrations/edit-page/action-configure/action-configure.component.scss
@@ -1,52 +1,52 @@
 .action-configure {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    overflow: visible;
-    .toolbar {
-        flex: 0 0 auto;
-        margin: 0 -20px;
-        .toolbar-pf {
-            background: none !important;
-            border: none !important;
-            margin: 0;
-            padding: 0 0 10px 0;
-            .breadcrumb {
-                padding: 0;
-                margin: 0;
-            }
-            .toolbar-pf-actions {
-                margin-bottom: 0;
-            }
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: visible;
+  .toolbar {
+    flex: 0 0 auto;
+    margin: 0 -20px;
+    .toolbar-pf {
+      background: none !important;
+      border: none !important;
+      margin: 0;
+      padding: 0 0 10px 0;
+      .breadcrumb {
+        padding: 0;
+        margin: 0;
+      }
+      .toolbar-pf-actions {
+        margin-bottom: 0;
+      }
+    }
+  }
+  .wizard-pf-body {
+    flex: 1 1 auto;
+    position: relative;
+    overflow-y: scroll;
+    margin-left: -20px;
+    padding-left: 20px;
+    margin-right: -20px;
+    padding-right: 20px;
+    margin-bottom: -20px;
+  }
+  .pre-content {
+    .toolbar-pf {
+      background: none !important;
+      border: none !important;
+      .search {
+        width: 50% !important;
+        .input-group {
+          width: 80% !important;
         }
+      }
     }
-    .wizard-pf-body {
-        flex: 1 1 auto;
-        position: relative;
-        overflow-y: scroll;
-        margin-left: -20px;
-        padding-left: 20px;
-        margin-right: -20px;
-        padding-right: 20px;
-        margin-bottom: -20px;
+  }
+  /deep/ .control-buttons {
+    margin-right: 15px;
+    .btn {
+      margin-top: 10px;
+      margin-left: 10px;
     }
-    .pre-content {
-        .toolbar-pf {
-            background: none !important;
-            border: none !important;
-            .search {
-                width: 50% !important;
-                .input-group {
-                    width: 80% !important;
-                }
-            }
-        }
-    }
-    /deep/ .control-buttons {
-        margin-right: 15px;
-        .btn {
-            margin-top: 10px;
-            margin-left: 10px;
-        }
-    }
+  }
 }

--- a/src/app/integrations/edit-page/action-configure/action-configure.component.ts
+++ b/src/app/integrations/edit-page/action-configure/action-configure.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { FormGroup } from '@angular/forms';
 import {
   DynamicFormControlModel,
-  DynamicFormService,
+  DynamicFormService
 } from '@ng-dynamic-forms/core';
 
 import { IntegrationSupportService } from '../../../store/integration-support.service';
@@ -19,7 +19,7 @@ const category = getCategory('IntegrationsCreatePage');
 @Component({
   selector: 'syndesis-integrations-action-configure',
   templateUrl: 'action-configure.component.html',
-  styleUrls: ['./action-configure.component.scss'],
+  styleUrls: ['./action-configure.component.scss']
 })
 export class IntegrationsConfigureActionComponent extends FlowPage
   implements OnInit, OnDestroy {
@@ -43,7 +43,7 @@ export class IntegrationsConfigureActionComponent extends FlowPage
     public formFactory: FormFactoryService,
     public formService: DynamicFormService,
     public detector: ChangeDetectorRef,
-    public integrationSupport: IntegrationSupportService,
+    public integrationSupport: IntegrationSupportService
   ) {
     super(currentFlow, route, router, detector);
   }
@@ -70,16 +70,16 @@ export class IntegrationsConfigureActionComponent extends FlowPage
           // all done...
           this.router.navigate(['save-or-add-step'], {
             queryParams: { validate: true },
-            relativeTo: this.route.parent,
+            relativeTo: this.route.parent
           });
         } else {
           // go to the next page...
           this.router.navigate(
             ['action-configure', this.position, this.page - 1],
-            { relativeTo: this.route.parent },
+            { relativeTo: this.route.parent }
           );
         }
-      },
+      }
     });
   }
 
@@ -95,43 +95,52 @@ export class IntegrationsConfigureActionComponent extends FlowPage
           // properties defined in previous steps we need to fetch metadata one
           // more time and apply those action property values that we get
           if (Object.keys(this.step.configuredProperties).length > 0) {
-            this.integrationSupport.fetchMetadata(
-              this.step.connection,
-              this.step.action,
-              data,
-            )
-            .toPromise()
-            .then(response => {
-              log.debug('Response: ' + JSON.stringify(response, undefined, 2));
-              const definition: any = response['_body'] ? JSON.parse(response['_body']) : undefined;
-              for (const actionProperty of Object.keys(data)) {
-                if (data[actionProperty] == null) {
-                  this.step.configuredProperties[actionProperty] = definition.propertyDefinitionSteps.map(actionDefinitionStep => {
-                    return actionDefinitionStep.properties[actionProperty].defaultValue;
-                  })[0];
+            this.integrationSupport
+              .fetchMetadata(this.step.connection, this.step.action, data)
+              .toPromise()
+              .then(response => {
+                log.debug(
+                  'Response: ' + JSON.stringify(response, undefined, 2)
+                );
+                const definition: any = response['_body']
+                  ? JSON.parse(response['_body'])
+                  : undefined;
+                for (const actionProperty of Object.keys(data)) {
+                  if (data[actionProperty] == null) {
+                    this.step.configuredProperties[
+                      actionProperty
+                    ] = definition.propertyDefinitionSteps.map(
+                      actionDefinitionStep => {
+                        return actionDefinitionStep.properties[actionProperty]
+                          .defaultValue;
+                      }
+                    )[0];
+                  }
                 }
-              }
-            })
-            .catch(response => {
-              this.error = {
-                message: response.message || response.userMsg || response.developerMsg,
-              };
-            });
+              })
+              .catch(response => {
+                this.error = {
+                  message:
+                    response.message ||
+                    response.userMsg ||
+                    response.developerMsg
+                };
+              });
           }
 
           // all done...
           this.router.navigate(['save-or-add-step'], {
             queryParams: { validate: true },
-            relativeTo: this.route.parent,
+            relativeTo: this.route.parent
           });
         } else {
           // go to the next page...
           this.router.navigate(
             ['action-configure', this.position, this.page + 1],
-            { relativeTo: this.route.parent },
+            { relativeTo: this.route.parent }
           );
         }
-      },
+      }
     });
   }
 
@@ -140,7 +149,7 @@ export class IntegrationsConfigureActionComponent extends FlowPage
     const step = <Step>this.currentFlow.getStep(this.position);
     if (!step) {
       this.router.navigate(['connection-select', this.position], {
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
       return;
     }
@@ -152,7 +161,7 @@ export class IntegrationsConfigureActionComponent extends FlowPage
       .fetchMetadata(
         this.step.connection,
         this.step.action,
-        this.configuredPropertiesForMetadataCall(),
+        this.configuredPropertiesForMetadataCall()
       )
       .toPromise()
       .then(response => {
@@ -172,7 +181,7 @@ export class IntegrationsConfigureActionComponent extends FlowPage
         } catch (err) {
           // bailout at this point...
           this.initForm(position, page, undefined, {
-            message: response['_body'],
+            message: response['_body']
           });
         }
       });
@@ -192,7 +201,7 @@ export class IntegrationsConfigureActionComponent extends FlowPage
       // TODO figure out how to get a link in here that works
       this.error = {
         class: 'alert alert-info',
-        message: 'There are no properties to configure for this action',
+        message: 'There are no properties to configure for this action'
       };
       this.detector.detectChanges();
       setTimeout(() => {
@@ -204,7 +213,7 @@ export class IntegrationsConfigureActionComponent extends FlowPage
       definition.propertyDefinitionSteps.length - 1);
     if (definition.propertyDefinitionSteps && page <= lastPage) {
       this.definition = JSON.parse(
-        JSON.stringify(definition.propertyDefinitionSteps[page]),
+        JSON.stringify(definition.propertyDefinitionSteps[page])
       );
       this.formConfig = this.definition.properties;
     } else {
@@ -217,14 +226,14 @@ export class IntegrationsConfigureActionComponent extends FlowPage
     }
     this.formModel = this.formFactory.createFormModel(
       this.formConfig,
-      this.step.configuredProperties,
+      this.step.configuredProperties
     );
     this.formGroup = this.formService.createFormGroup(this.formModel);
     setTimeout(() => {
       try {
         this.currentFlow.events.emit({
           kind: 'integration-action-configure',
-          position: this.position,
+          position: this.position
         });
         this.loading = false;
         this.detector.detectChanges();
@@ -263,11 +272,11 @@ export class IntegrationsConfigureActionComponent extends FlowPage
         }
         const page = (this.page = Number.parseInt(params.get('page')));
         const position = (this.position = Number.parseInt(
-          params.get('position'),
+          params.get('position')
         ));
         this.loading = true;
         this.initialize(position, page);
-      },
+      }
     );
   }
 

--- a/src/app/integrations/edit-page/action-select/action-select.component.ts
+++ b/src/app/integrations/edit-page/action-select/action-select.component.ts
@@ -1,9 +1,4 @@
-import {
-  Component,
-  OnInit,
-  OnDestroy,
-  ChangeDetectorRef,
-} from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
@@ -21,7 +16,7 @@ const category = getCategory('Integrations');
 @Component({
   selector: 'syndesis-integrations-action-select',
   templateUrl: 'action-select.component.html',
-  styleUrls: ['./action-select.component.scss'],
+  styleUrls: ['./action-select.component.scss']
 })
 export class IntegrationsSelectActionComponent extends FlowPage
   implements OnInit, OnDestroy {
@@ -39,7 +34,7 @@ export class IntegrationsSelectActionComponent extends FlowPage
     public currentFlow: CurrentFlow,
     public route: ActivatedRoute,
     public router: Router,
-    public detector: ChangeDetectorRef,
+    public detector: ChangeDetectorRef
   ) {
     super(currentFlow, route, router, detector);
     this.connector = connectorStore.resource;
@@ -55,9 +50,9 @@ export class IntegrationsSelectActionComponent extends FlowPage
       action: action,
       onSave: () => {
         this.router.navigate(['action-configure', this.position], {
-          relativeTo: this.route.parent,
+          relativeTo: this.route.parent
         });
-      },
+      }
     });
   }
 
@@ -73,19 +68,19 @@ export class IntegrationsSelectActionComponent extends FlowPage
     if (!step) {
       // safety net
       this.router.navigate(['save-or-add-step'], {
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
       return;
     }
     if (!step.connection) {
       this.router.navigate(['connection-select', this.position], {
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
       return;
     }
     if (step.action) {
       this.router.navigate(['action-configure', this.position], {
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
       return;
     }
@@ -106,11 +101,11 @@ export class IntegrationsSelectActionComponent extends FlowPage
     this.actions = this.connector
       .filter(connector => connector !== undefined)
       .map(connector => connector.actions);
-    this.actionsSubscription = this.actions.subscribe(_ => this.currentFlow.events
-      .emit({
+    this.actionsSubscription = this.actions.subscribe(_ =>
+      this.currentFlow.events.emit({
         kind: 'integration-action-select',
-        position: this.position,
-      }),
+        position: this.position
+      })
     );
     this.routeSubscription = this.route.params
       .pluck<Params, string>('position')

--- a/src/app/integrations/edit-page/child-aware-page.ts
+++ b/src/app/integrations/edit-page/child-aware-page.ts
@@ -6,7 +6,7 @@ export abstract class ChildAwarePage {
   constructor(
     public currentFlow: CurrentFlow,
     public route: ActivatedRoute,
-    public router: Router,
+    public router: Router
   ) {}
 
   getChildPath(route: ActivatedRoute = this.route) {

--- a/src/app/integrations/edit-page/common/cancel-add-step.component.spec.ts
+++ b/src/app/integrations/edit-page/common/cancel-add-step.component.spec.ts
@@ -3,14 +3,16 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { CurrentFlow } from '../current-flow.service';
 
 describe('CancelAddStepComponent', () => {
-
   let component, currentFlow, route, router;
 
   beforeEach(() => {
-    currentFlow = jasmine.createSpyObj('currentFlow', ['getLastPosition', 'getStep']);
+    currentFlow = jasmine.createSpyObj('currentFlow', [
+      'getLastPosition',
+      'getStep'
+    ]);
     currentFlow.events = jasmine.createSpyObj('events', ['emit']);
     route = {
-      paramMap: jasmine.createSpyObj('paramMap', ['subscribe']),
+      paramMap: jasmine.createSpyObj('paramMap', ['subscribe'])
     };
     router = jasmine.createSpyObj('router', ['navigate']);
     component = new CancelAddStepComponent(currentFlow, route, router);
@@ -53,5 +55,4 @@ describe('CancelAddStepComponent', () => {
       expect(currentFlow.events.emit).toHaveBeenCalled();
     });
   });
-
 });

--- a/src/app/integrations/edit-page/common/cancel-add-step.component.ts
+++ b/src/app/integrations/edit-page/common/cancel-add-step.component.ts
@@ -9,7 +9,7 @@ import { CurrentFlow } from '../current-flow.service';
             class="btn btn-default"
             (click)="onClick()"
             *ngIf="isIntermediateStep()">Cancel</button>
-  `,
+  `
 })
 export class CancelAddStepComponent implements OnInit {
   private position: number;
@@ -17,12 +17,12 @@ export class CancelAddStepComponent implements OnInit {
   constructor(
     public currentFlow: CurrentFlow,
     public route: ActivatedRoute,
-    public router: Router,
+    public router: Router
   ) {}
 
   ngOnInit() {
     this.route.paramMap.subscribe(
-      paramMap => (this.position = +paramMap.get('position')),
+      paramMap => (this.position = +paramMap.get('position'))
     );
   }
 
@@ -43,13 +43,13 @@ export class CancelAddStepComponent implements OnInit {
         position: this.position,
         onSave: () => {
           this.router.navigate(['save-or-add-step'], {
-            relativeTo: this.route.parent,
+            relativeTo: this.route.parent
           });
-        },
+        }
       });
     } else {
       this.router.navigate(['save-or-add-step'], {
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
     }
   }

--- a/src/app/integrations/edit-page/connection-select/connection-select.component.ts
+++ b/src/app/integrations/edit-page/connection-select/connection-select.component.ts
@@ -16,15 +16,15 @@ const category = getCategory('Integrations');
   moduleId: module.id,
   selector: 'syndesis-integrations-connection-select',
   templateUrl: 'connection-select.component.html',
-  styleUrls: ['./connection-select.component.scss'],
+  styleUrls: ['./connection-select.component.scss']
 })
 export class IntegrationsSelectConnectionComponent extends FlowPage
   implements OnInit, OnDestroy {
   loading: Observable<boolean>;
   connections: Observable<Connections>;
-  filteredConnections: Subject<Connections> = new BehaviorSubject(
-    <Connections>{},
-  );
+  filteredConnections: Subject<
+    Connections
+  > = new BehaviorSubject(<Connections>{});
   routeSubscription: Subscription;
   position: number;
 
@@ -33,7 +33,7 @@ export class IntegrationsSelectConnectionComponent extends FlowPage
     public currentFlow: CurrentFlow,
     public route: ActivatedRoute,
     public router: Router,
-    public detector: ChangeDetectorRef,
+    public detector: ChangeDetectorRef
   ) {
     super(currentFlow, route, router, detector);
     this.loading = store.loading;
@@ -56,9 +56,9 @@ export class IntegrationsSelectConnectionComponent extends FlowPage
       connection: connection,
       onSave: () => {
         this.router.navigate(['action-select', this.position], {
-          relativeTo: this.route.parent,
+          relativeTo: this.route.parent
         });
-      },
+      }
     });
   }
 
@@ -86,20 +86,20 @@ export class IntegrationsSelectConnectionComponent extends FlowPage
     if (!step || step.stepKind !== 'endpoint') {
       // safety net
       this.router.navigate(['save-or-add-step'], {
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
       return;
     }
     if (step.connection) {
       this.router.navigate(['action-select', this.position], {
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
       return;
     }
     this.store.loadAll();
     this.currentFlow.events.emit({
       kind: 'integration-connection-select',
-      position: this.position,
+      position: this.position
     });
   }
 

--- a/src/app/integrations/edit-page/current-flow.service.spec.ts
+++ b/src/app/integrations/edit-page/current-flow.service.spec.ts
@@ -13,7 +13,7 @@ import {
   Step,
   Steps,
   Action,
-  TypeFactory,
+  TypeFactory
 } from '../../model';
 import { EventsService } from '../../store/entity/events.service';
 import { SyndesisCommonModule } from '../../common/common.module';
@@ -21,10 +21,7 @@ import { SyndesisCommonModule } from '../../common/common.module';
 describe('CurrentFlow', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        RestangularModule.forRoot(),
-        SyndesisCommonModule.forRoot(),
-      ],
+      imports: [RestangularModule.forRoot(), SyndesisCommonModule.forRoot()],
       providers: [
         CurrentFlow,
         IntegrationStore,
@@ -37,9 +34,9 @@ describe('CurrentFlow', () => {
           useFactory: (backend, options) => {
             return new Http(backend, options);
           },
-          deps: [MockBackend, RequestOptions],
-        },
-      ],
+          deps: [MockBackend, RequestOptions]
+        }
+      ]
     });
   });
 
@@ -82,7 +79,7 @@ describe('CurrentFlow', () => {
       service.integration = getDummyIntegration();
       const step = service.getPreviousConnection(2);
       expect(step.id).toEqual('3');
-    }),
+    })
   );
 
   it(
@@ -91,7 +88,7 @@ describe('CurrentFlow', () => {
       service.integration = getDummyIntegration();
       const step = service.getSubsequentConnection(2);
       expect(step.id).toEqual('4');
-    }),
+    })
   );
 
   it(
@@ -101,7 +98,7 @@ describe('CurrentFlow', () => {
       const steps = service.getSubsequentConnections(2);
       expect(steps.length).toEqual(1);
       expect(steps[0].id).toEqual('4');
-    }),
+    })
   );
 
   it(
@@ -111,7 +108,7 @@ describe('CurrentFlow', () => {
       const steps = service.getPreviousConnections(2);
       expect(steps.length).toEqual(2);
       expect(steps[0].id).toEqual('foobar');
-    }),
+    })
   );
 
   it(
@@ -120,7 +117,7 @@ describe('CurrentFlow', () => {
       service.integration = getDummyIntegration();
       const conn = service.getStartConnection();
       expect(conn.connectorId).toEqual('timer');
-    }),
+    })
   );
 
   it(
@@ -129,7 +126,7 @@ describe('CurrentFlow', () => {
       service.integration = getDummyIntegration();
       const conn = service.getEndConnection();
       expect(conn.connectorId).toEqual('http');
-    }),
+    })
   );
 
   it(
@@ -140,7 +137,7 @@ describe('CurrentFlow', () => {
       expect(steps.length).toEqual(2);
       expect(steps[0].id).toEqual('3');
       expect(steps[0].stepKind).toEqual('endpoint');
-    }),
+    })
   );
 
   it(
@@ -151,6 +148,6 @@ describe('CurrentFlow', () => {
       expect(service.getEndConnection()).toBeUndefined();
       expect(service.getFirstPosition()).toEqual(0);
       expect(service.getLastPosition()).toEqual(1);
-    }),
+    })
   );
 });

--- a/src/app/integrations/edit-page/current-flow.service.ts
+++ b/src/app/integrations/edit-page/current-flow.service.ts
@@ -7,7 +7,7 @@ import {
   Integration,
   Step,
   Connection,
-  TypeFactory,
+  TypeFactory
 } from '../../model';
 import { log, getCategory } from '../../logging';
 
@@ -28,7 +28,7 @@ export class CurrentFlow {
 
   constructor(private store: IntegrationStore) {
     this.subscription = this.events.subscribe((event: FlowEvent) =>
-      this.handleEvent(event),
+      this.handleEvent(event)
     );
   }
 
@@ -268,7 +268,7 @@ export class CurrentFlow {
         setTimeout(() => {
           if (this.isEmpty()) {
             this.events.emit({
-              kind: 'integration-no-connections',
+              kind: 'integration-no-connections'
             });
           }
         }, 10);
@@ -325,7 +325,7 @@ export class CurrentFlow {
             position +
             ' step: ' +
             JSON.stringify(step),
-          category,
+          category
         );
         break;
       }
@@ -340,7 +340,7 @@ export class CurrentFlow {
         this.maybeDoAction(event['onSave']);
         log.debugc(
           () => 'Set action ' + action.name + ' at position: ' + position,
-          category,
+          category
         );
         break;
       }
@@ -355,7 +355,7 @@ export class CurrentFlow {
         log.debugc(
           () =>
             'Set connection ' + connection.name + ' at position: ' + position,
-          category,
+          category
         );
         break;
       }
@@ -373,7 +373,9 @@ export class CurrentFlow {
         // poor man's clone in case we need to munge the data
         const integration = this.getIntegrationClone();
         const tags = integration.tags || [];
-        const connectorIds = this.getSubsequentConnections(0).map( step => step.connection.connectorId);
+        const connectorIds = this.getSubsequentConnections(0).map(
+          step => step.connection.connectorId
+        );
         connectorIds.forEach(id => {
           if (tags.indexOf(id) === -1) {
             tags.push(id);
@@ -384,7 +386,7 @@ export class CurrentFlow {
           (i: Integration) => {
             log.debugc(
               () => 'Saved integration: ' + JSON.stringify(i, undefined, 2),
-              category,
+              category
             );
             const action = event['action'];
             if (action && typeof action === 'function') {
@@ -397,14 +399,14 @@ export class CurrentFlow {
               () =>
                 'Error saving integration: ' +
                 JSON.stringify(reason, undefined, 2),
-              category,
+              category
             );
             const errorAction = event['error'];
             if (errorAction && typeof errorAction === 'function') {
               errorAction(reason);
             }
             sub.unsubscribe();
-          },
+          }
         );
         break;
       }
@@ -449,7 +451,7 @@ export class CurrentFlow {
     setTimeout(() => {
       this.events.emit({
         kind: 'integration-updated',
-        integration: this.integration,
+        integration: this.integration
       });
     }, 10);
   }

--- a/src/app/integrations/edit-page/edit-page.component.spec.ts
+++ b/src/app/integrations/edit-page/edit-page.component.spec.ts
@@ -38,32 +38,32 @@ describe('IntegrationsEditComponent', () => {
           PopoverModule.forRoot(),
           CollapseModule.forRoot(),
           StoreModule,
-          ToolbarModule,
+          ToolbarModule
         ],
         declarations: [
           IntegrationsEditPage,
           ConnectionsListComponent,
           FlowViewComponent,
-          FlowViewStepComponent,
+          FlowViewStepComponent
         ],
         providers: [
           MockBackend,
           {
             provide: RequestOptions,
-            useClass: BaseRequestOptions,
+            useClass: BaseRequestOptions
           },
           {
             provide: Http,
             useFactory: (backend, options) => {
               return new Http(backend, options);
             },
-            deps: [MockBackend, RequestOptions],
+            deps: [MockBackend, RequestOptions]
           },
           NavigationService,
-          CurrentFlow,
-        ],
+          CurrentFlow
+        ]
       }).compileComponents();
-    }),
+    })
   );
 
   // TODO: Add separate test for editing

--- a/src/app/integrations/edit-page/edit-page.component.ts
+++ b/src/app/integrations/edit-page/edit-page.component.ts
@@ -17,7 +17,7 @@ const category = getCategory('IntegrationsEditPage');
 @Component({
   selector: 'syndesis-integrations-edit-page',
   templateUrl: './edit-page.component.html',
-  styleUrls: ['./edit-page.component.scss'],
+  styleUrls: ['./edit-page.component.scss']
 })
 export class IntegrationsEditPage extends ChildAwarePage
   implements OnInit, OnDestroy {
@@ -41,7 +41,7 @@ export class IntegrationsEditPage extends ChildAwarePage
     public detector: ChangeDetectorRef,
     public nav: NavigationService,
     public tourService: TourService,
-    private userService: UserService,
+    private userService: UserService
   ) {
     super(currentFlow, route, router);
     this.integration = this.store.resource;
@@ -50,7 +50,7 @@ export class IntegrationsEditPage extends ChildAwarePage
     this.flowSubscription = this.currentFlow.events.subscribe(
       (event: FlowEvent) => {
         this.handleFlowEvent(event);
-      },
+      }
     );
   }
 
@@ -111,7 +111,7 @@ export class IntegrationsEditPage extends ChildAwarePage
     if (validate) {
       this.router.navigate(['save-or-add-step'], {
         queryParams: { validate: true },
-        relativeTo: this.route,
+        relativeTo: this.route
       });
     }
   }
@@ -196,7 +196,7 @@ export class IntegrationsEditPage extends ChildAwarePage
           }
           */
         }
-      },
+      }
     );
     this.routeSubscription = this.route.params
       .pluck<Params, string>('integrationId')

--- a/src/app/integrations/edit-page/flow-page.ts
+++ b/src/app/integrations/edit-page/flow-page.ts
@@ -14,12 +14,12 @@ export abstract class FlowPage implements OnDestroy {
     public currentFlow: CurrentFlow,
     public route: ActivatedRoute,
     public router: Router,
-    public detector: ChangeDetectorRef,
+    public detector: ChangeDetectorRef
   ) {
     this.flowSubscription = this.currentFlow.events.subscribe(
       (event: FlowEvent) => {
         this.handleFlowEvent(event);
-      },
+      }
     );
   }
 
@@ -28,7 +28,9 @@ export abstract class FlowPage implements OnDestroy {
   }
 
   get integrationName() {
-    return this.currentFlow.integration ? this.currentFlow.integration.name : undefined;
+    return this.currentFlow.integration
+      ? this.currentFlow.integration.name
+      : undefined;
   }
 
   cancel() {
@@ -54,7 +56,7 @@ export abstract class FlowPage implements OnDestroy {
       this.currentFlow.integration.name === ''
     ) {
       this.router.navigate(['integration-basics'], {
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
       this.saveInProgress = false;
       this.publishInProgress = false;
@@ -79,7 +81,7 @@ export abstract class FlowPage implements OnDestroy {
           this.publishInProgress = false;
           this.detector.detectChanges();
         }, 10);
-      },
+      }
     });
   }
 
@@ -95,7 +97,7 @@ export abstract class FlowPage implements OnDestroy {
   }
 
   publish(
-    status: 'Draft' | 'Activated' | 'Deactivated' | 'Deleted' = 'Activated',
+    status: 'Draft' | 'Activated' | 'Deactivated' | 'Deleted' = 'Activated'
   ) {
     this.currentFlow.integration.desiredStatus = status;
     this.publishInProgress = true;

--- a/src/app/integrations/edit-page/flow-view/flow-view-step.component.ts
+++ b/src/app/integrations/edit-page/flow-view/flow-view-step.component.ts
@@ -16,7 +16,7 @@ const category = getCategory('IntegrationsCreatePage');
 @Component({
   selector: 'syndesis-integrations-flow-view-step',
   templateUrl: './flow-view-step.component.html',
-  styleUrls: ['./flow-view-step.component.scss'],
+  styleUrls: ['./flow-view-step.component.scss']
 })
 export class FlowViewStepComponent extends ChildAwarePage {
   // the step object in the current flow
@@ -39,7 +39,7 @@ export class FlowViewStepComponent extends ChildAwarePage {
     public router: Router,
     private stepStore: StepStore,
     private modalService: ModalService,
-    private detector: ChangeDetectorRef,
+    private detector: ChangeDetectorRef
   ) {
     super(currentFlow, route, router);
   }
@@ -95,7 +95,7 @@ export class FlowViewStepComponent extends ChildAwarePage {
   deletePrompt() {
     this.modalService
       .show('delete-integration-step-' + this.position)
-      .then( modal => {
+      .then(modal => {
         if (modal.result) {
           this.deleteStep();
         }
@@ -119,15 +119,15 @@ export class FlowViewStepComponent extends ChildAwarePage {
           }
           if (isFirst || isLast) {
             this.router.navigate(['connection-select', position], {
-              relativeTo: this.route,
+              relativeTo: this.route
             });
           } else {
             this.router.navigate(['save-or-add-step'], {
-              relativeTo: this.route,
+              relativeTo: this.route
             });
           }
         }, 10);
-      },
+      }
     });
   }
 
@@ -295,12 +295,12 @@ export class FlowViewStepComponent extends ChildAwarePage {
     if (step && !this.stepIsComplete(step)) {
       return;
     }
-    const route  = [page, this.getPosition()];
+    const route = [page, this.getPosition()];
     if (index !== undefined) {
       route.push(index);
     }
     this.router.navigate(route, {
-      relativeTo: this.route,
+      relativeTo: this.route
     });
   }
 

--- a/src/app/integrations/edit-page/flow-view/flow-view.component.spec.ts
+++ b/src/app/integrations/edit-page/flow-view/flow-view.component.spec.ts
@@ -36,29 +36,29 @@ describe('IntegrationsCreateComponent', () => {
           PopoverModule.forRoot(),
           CollapseModule.forRoot(),
           SyndesisCommonModule.forRoot(),
-          CollapseModule,
+          CollapseModule
         ],
         declarations: [FlowViewComponent, FlowViewStepComponent],
         providers: [
           MockBackend,
           {
             provide: RequestOptions,
-            useClass: BaseRequestOptions,
+            useClass: BaseRequestOptions
           },
           {
             provide: Http,
             useFactory: (backend, options) => {
               return new Http(backend, options);
             },
-            deps: [MockBackend, RequestOptions],
+            deps: [MockBackend, RequestOptions]
           },
           CurrentFlow,
           IntegrationStore,
           IntegrationService,
-          EventsService,
-        ],
+          EventsService
+        ]
       }).compileComponents();
-    }),
+    })
   );
 
   beforeEach(() => {

--- a/src/app/integrations/edit-page/flow-view/flow-view.component.ts
+++ b/src/app/integrations/edit-page/flow-view/flow-view.component.ts
@@ -6,7 +6,7 @@ import {
   OnDestroy,
   ChangeDetectorRef,
   ViewChild,
-  ViewChildren,
+  ViewChildren
 } from '@angular/core';
 import { ActivatedRoute, Params, Router, UrlSegment } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
@@ -23,7 +23,7 @@ const category = getCategory('IntegrationsCreatePage');
 @Component({
   selector: 'syndesis-integrations-flow-view',
   templateUrl: './flow-view.component.html',
-  styleUrls: ['./flow-view.component.scss'],
+  styleUrls: ['./flow-view.component.scss']
 })
 export class FlowViewComponent extends ChildAwarePage
   implements OnInit, OnDestroy {
@@ -41,13 +41,13 @@ export class FlowViewComponent extends ChildAwarePage
     public currentFlow: CurrentFlow,
     public route: ActivatedRoute,
     public router: Router,
-    public detector: ChangeDetectorRef,
+    public detector: ChangeDetectorRef
   ) {
     super(currentFlow, route, router);
     this.flowSubscription = this.currentFlow.events.subscribe(
       (event: FlowEvent) => {
         this.handleFlowEvent(event);
-      },
+      }
     );
   }
 
@@ -129,10 +129,10 @@ export class FlowViewComponent extends ChildAwarePage
             // @TODO: Remove this try/catch once ChangeDetection is restored
           }
           this.router.navigate(['step-select', position + 1], {
-            relativeTo: this.route,
+            relativeTo: this.route
           });
         }, 10);
-      },
+      }
     });
   }
 
@@ -151,10 +151,10 @@ export class FlowViewComponent extends ChildAwarePage
             // @TODO: Remove this try/catch once ChangeDetection is restored
           }
           this.router.navigate(['connection-select', position + 1], {
-            relativeTo: this.route,
+            relativeTo: this.route
           });
         }, 10);
-      },
+      }
     });
   }
 
@@ -166,7 +166,7 @@ export class FlowViewComponent extends ChildAwarePage
     this.currentFlow.events.emit({
       kind: 'integration-set-property',
       property: 'name',
-      value: name,
+      value: name
     });
   }
 

--- a/src/app/integrations/edit-page/integration-basics/integration-basics.component.scss
+++ b/src/app/integrations/edit-page/integration-basics/integration-basics.component.scss
@@ -47,9 +47,9 @@ div.integration-basics {
       border: 1px solid #bbb;
       border-radius: 1px;
       box-shadow: inset 0 2px 2px rgba(0, 0, 0, 0.075);
-      -webkit-transition: border-color ease-in-out .15s,
-        box-shadow ease-in-out .15s;
-      transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+      -webkit-transition: border-color ease-in-out 0.15s,
+        box-shadow ease-in-out 0.15s;
+      transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
     }
   }
 }

--- a/src/app/integrations/edit-page/integration-basics/integration-basics.component.ts
+++ b/src/app/integrations/edit-page/integration-basics/integration-basics.component.ts
@@ -8,14 +8,14 @@ import { FlowPage } from '../flow-page';
 @Component({
   selector: 'syndesis-integrations-integration-basics',
   templateUrl: 'integration-basics.component.html',
-  styleUrls: ['./integration-basics.component.scss'],
+  styleUrls: ['./integration-basics.component.scss']
 })
 export class IntegrationBasicsComponent extends FlowPage {
   constructor(
     public currentFlow: CurrentFlow,
     public route: ActivatedRoute,
     public router: Router,
-    public detector: ChangeDetectorRef,
+    public detector: ChangeDetectorRef
   ) {
     super(currentFlow, route, router, detector);
   }
@@ -30,7 +30,7 @@ export class IntegrationBasicsComponent extends FlowPage {
   continue() {
     this.router.navigate(['save-or-add-step'], {
       queryParams: { validate: true },
-      relativeTo: this.route.parent,
+      relativeTo: this.route.parent
     });
   }
 
@@ -43,7 +43,7 @@ export class IntegrationBasicsComponent extends FlowPage {
     this.currentFlow.events.emit({
       kind: 'integration-set-property',
       property: 'name',
-      value: name,
+      value: name
     });
   }
 
@@ -55,7 +55,7 @@ export class IntegrationBasicsComponent extends FlowPage {
     this.currentFlow.events.emit({
       kind: 'integration-set-property',
       property: 'description',
-      value: description,
+      value: description
     });
   }
 
@@ -72,7 +72,7 @@ export class IntegrationBasicsComponent extends FlowPage {
     this.currentFlow.events.emit({
       kind: 'integration-set-property',
       property: 'tags',
-      value: _tags,
+      value: _tags
     });
   }
 }

--- a/src/app/integrations/edit-page/list-actions/list-actions.component.spec.ts
+++ b/src/app/integrations/edit-page/list-actions/list-actions.component.spec.ts
@@ -16,11 +16,11 @@ describe('ListActionsComponent', () => {
         imports: [
           SyndesisCommonModule,
           RouterTestingModule.withRoutes([]),
-          StoreModule,
+          StoreModule
         ],
-        declarations: [ListActionsComponent],
+        declarations: [ListActionsComponent]
       }).compileComponents();
-    }),
+    })
   );
 
   beforeEach(() => {

--- a/src/app/integrations/edit-page/list-actions/list-actions.component.ts
+++ b/src/app/integrations/edit-page/list-actions/list-actions.component.ts
@@ -9,7 +9,7 @@ const category = getCategory('Actions');
 @Component({
   selector: 'syndesis-list-actions',
   templateUrl: './list-actions.component.html',
-  styleUrls: ['./list-actions.component.scss'],
+  styleUrls: ['./list-actions.component.scss']
 })
 export class ListActionsComponent implements OnInit {
   truncateLimit = 80;
@@ -36,7 +36,7 @@ export class ListActionsComponent implements OnInit {
   ngOnInit() {
     log.debugc(
       () => 'Got actions: ' + JSON.stringify(this.actions, undefined, 2),
-      category,
+      category
     );
   }
 }

--- a/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.ts
+++ b/src/app/integrations/edit-page/save-or-add-step/save-or-add-step.component.ts
@@ -14,7 +14,7 @@ const category = getCategory('IntegrationsCreatePage');
 @Component({
   selector: 'syndesis-integrations-save-or-add-step',
   templateUrl: 'save-or-add-step.component.html',
-  styleUrls: ['./save-or-add-step.component.scss'],
+  styleUrls: ['./save-or-add-step.component.scss']
 })
 export class IntegrationsSaveOrAddStepComponent extends FlowPage
   implements OnInit, OnDestroy {
@@ -26,7 +26,7 @@ export class IntegrationsSaveOrAddStepComponent extends FlowPage
     public store: IntegrationStore,
     public route: ActivatedRoute,
     public router: Router,
-    public detector: ChangeDetectorRef,
+    public detector: ChangeDetectorRef
   ) {
     super(currentFlow, route, router, detector);
   }
@@ -73,14 +73,14 @@ export class IntegrationsSaveOrAddStepComponent extends FlowPage
   addNew(type: string) {
     this.currentFlow.events.emit({
       kind: 'integration-add-step',
-      type: type,
+      type: type
     });
   }
 
   showPopouts(type: string) {
     this.currentFlow.events.emit({
       kind: 'integration-show-popouts',
-      type: type,
+      type: type
     });
   }
 
@@ -90,9 +90,9 @@ export class IntegrationsSaveOrAddStepComponent extends FlowPage
       position: position,
       onSave: () => {
         this.router.navigate(['step-select', position + 1], {
-          relativeTo: this.route,
+          relativeTo: this.route
         });
-      },
+      }
     });
   }
 
@@ -102,9 +102,9 @@ export class IntegrationsSaveOrAddStepComponent extends FlowPage
       position: position,
       onSave: () => {
         this.router.navigate(['connection-select', position + 1], {
-          relativeTo: this.route,
+          relativeTo: this.route
         });
-      },
+      }
     });
   }
 
@@ -135,14 +135,14 @@ export class IntegrationsSaveOrAddStepComponent extends FlowPage
     if (this.currentFlow.getStartConnection() === undefined) {
       this.router.navigate(
         ['connection-select', this.currentFlow.getFirstPosition()],
-        { relativeTo: this.route.parent },
+        { relativeTo: this.route.parent }
       );
       return;
     }
     if (this.currentFlow.getEndConnection() === undefined) {
       this.router.navigate(
         ['connection-select', this.currentFlow.getLastPosition()],
-        { relativeTo: this.route.parent },
+        { relativeTo: this.route.parent }
       );
       return;
     }
@@ -150,7 +150,7 @@ export class IntegrationsSaveOrAddStepComponent extends FlowPage
 
   ngOnInit() {
     const validate = this.route.queryParams.map(
-      params => params['validate'] || false,
+      params => params['validate'] || false
     );
     if (validate) {
       this.validateFlow();

--- a/src/app/integrations/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
+++ b/src/app/integrations/edit-page/step-configure/data-mapper/data-mapper-host.component.ts
@@ -3,20 +3,22 @@ import {
   Component,
   ViewChild,
   OnInit,
-  Input,
+  Input
 } from '@angular/core';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { Subscription } from 'rxjs/Subscription';
 
 import {
-  DocumentDefinition, MappingDefinition,
-  ConfigModel, MappingModel,
+  DocumentDefinition,
+  MappingDefinition,
+  ConfigModel,
+  MappingModel,
   InitializationService,
   ErrorHandlerService,
   DocumentManagementService,
   MappingManagementService,
   MappingSerializer,
-  DataMapperAppComponent,
+  DataMapperAppComponent
 } from '@atlasmap/atlasmap.data.mapper';
 
 import { ConfigService } from '../../../../config.service';
@@ -51,7 +53,7 @@ const MAPPING_KEY = 'atlasmapping';
         /* TODO probably a better way to set this height to the viewport */
         height: calc(100vh - 140px);
       }
-    `,
+    `
   ],
   providers: [
     // @FIXME - This overrides the provider singletons from this point on down the component subtree,
@@ -60,8 +62,8 @@ const MAPPING_KEY = 'atlasmapping';
     InitializationService,
     MappingManagementService,
     ErrorHandlerService,
-    DocumentManagementService,
-  ],
+    DocumentManagementService
+  ]
 })
 export class DataMapperHostComponent extends FlowPage implements OnInit {
   routeSubscription: Subscription;
@@ -86,13 +88,17 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
     public configService: ConfigService,
     public initializationService: InitializationService,
     public support: IntegrationSupportService,
-    public detector: ChangeDetectorRef,
+    public detector: ChangeDetectorRef
   ) {
     super(currentFlow, route, router, detector);
     this.resetConfig();
   }
 
-  createDocumentDefinition(connectorId: string, dataShape: DataShape, isSource = false) {
+  createDocumentDefinition(
+    connectorId: string,
+    dataShape: DataShape,
+    isSource = false
+  ) {
     if (!dataShape || !dataShape.kind) {
       // skip
       return;
@@ -103,17 +109,27 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
     // TODO not sure what to do for `none` or `any` here
     switch (kind) {
       case 'java':
-        const docDef: DocumentDefinition = this.cfg.addJavaDocument(type, isSource);
+        const docDef: DocumentDefinition = this.cfg.addJavaDocument(
+          type,
+          isSource
+        );
         this.support.requestJavaInspection(connectorId, type).subscribe(
           data => {
             const inspection: string = data['_body'];
-            log.infoc(() => 'Precomputed java document found for ' + type, category);
+            log.infoc(
+              () => 'Precomputed java document found for ' + type,
+              category
+            );
             log.debugc(() => inspection, category);
             docDef.initCfg.inspectionResultContents = inspection;
           },
           err => {
-            log.warnc(() => 'No precomputed java document found for ' + type + ': ' + err, category);
-          },
+            log.warnc(
+              () =>
+                'No precomputed java document found for ' + type + ': ' + err,
+              category
+            );
+          }
         );
         break;
       case 'json':
@@ -143,10 +159,22 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
     }
     this.cfg.mappings = new MappingDefinition();
 
-    const previousConnectorId: string = this.currentFlow.getPreviousConnection(this.position).connection.connectorId;
-    const subsequentConnectorId: string = this.currentFlow.getSubsequentConnection(this.position).connection.connectorId;
-    this.createDocumentDefinition(previousConnectorId, this.outputDataShape, true);
-    this.createDocumentDefinition(subsequentConnectorId, this.inputDataShape, false);
+    const previousConnectorId: string = this.currentFlow.getPreviousConnection(
+      this.position
+    ).connection.connectorId;
+    const subsequentConnectorId: string = this.currentFlow.getSubsequentConnection(
+      this.position
+    ).connection.connectorId;
+    this.createDocumentDefinition(
+      previousConnectorId,
+      this.outputDataShape,
+      true
+    );
+    this.createDocumentDefinition(
+      subsequentConnectorId,
+      this.inputDataShape,
+      false
+    );
 
     // TODO for now set a really long timeout
     this.cfg.initCfg.classPathFetchTimeoutInMilliseconds = 3600000;
@@ -157,7 +185,7 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
         MappingSerializer.deserializeMappingServiceJSON(
           JSON.parse(mappings),
           mappingDefinition,
-          this.cfg,
+          this.cfg
         );
       } catch (err) {
         // TODO popup or error alert?  At least catch this so we initialize
@@ -188,14 +216,14 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
       'debugClassPathServiceCalls',
       'debugValidationServiceCalls',
       'debugFieldActionServiceCalls',
-      'debugDocumentParsing',
+      'debugDocumentParsing'
     ];
     for (const debugConfigKey of debugConfigKeys) {
       let debugKeyValue = false;
       try {
         debugKeyValue = this.configService.getSettings(
           'datamapper',
-          debugConfigKey,
+          debugConfigKey
         );
       } catch (err) {
         // @TODO: Remove this try/catch once ChangeDetection is restored
@@ -208,7 +236,7 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
       (saveHandler: Function) => {
         const json = this.cfg.mappingService.serializeMappingsToJSON();
         const properties = {
-          atlasmapping: JSON.stringify(json),
+          atlasmapping: JSON.stringify(json)
         };
         this.currentFlow.events.emit({
           kind: 'integration-set-properties',
@@ -217,9 +245,9 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
           onSave: () => {
             this.cfg.mappingService.handleMappingSaveSuccess(saveHandler);
             log.debugc(() => 'Saved mapping file: ' + json, category);
-          },
+          }
         });
-      },
+      }
     );
 
     // make sure the property is set on the integration
@@ -227,13 +255,13 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
       kind: 'integration-set-properties',
       position: this.position,
       properties: {
-        atlasmapping: mappings ? mappings : '',
+        atlasmapping: mappings ? mappings : ''
       },
       onSave: () => {
         setTimeout(() => {
           this.initializeMapper();
         }, 10);
-      },
+      }
     });
   }
 
@@ -289,29 +317,29 @@ export class DataMapperHostComponent extends FlowPage implements OnInit {
     this.cfg.initCfg.baseJavaInspectionServiceUrl = this.fetchServiceUrl(
       'baseJavaInspectionServiceUrl',
       baseUrl + 'java/',
-      this.configService,
+      this.configService
     );
     this.cfg.initCfg.baseXMLInspectionServiceUrl = this.fetchServiceUrl(
       'baseXMLInspectionServiceUrl',
       baseUrl + 'xml/',
-      this.configService,
+      this.configService
     );
     this.cfg.initCfg.baseJSONInspectionServiceUrl = this.fetchServiceUrl(
       'baseJSONInspectionServiceUrl',
       baseUrl + 'json/',
-      this.configService,
+      this.configService
     );
     this.cfg.initCfg.baseMappingServiceUrl = this.fetchServiceUrl(
       'baseMappingServiceUrl',
       baseUrl,
-      this.configService,
+      this.configService
     );
   }
 
   private fetchServiceUrl(
     configKey: string,
     defaultUrl: string,
-    configService: ConfigService,
+    configService: ConfigService
   ): string {
     try {
       return configService.getSettings('datamapper', configKey);

--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.scss
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.scss
@@ -1,13 +1,17 @@
 .basic-filter {
   .basic-filter-form-container {
-    background: #FFFFFF;
+    background: #ffffff;
     padding: 30px;
 
     .basic-filter-form {
       .rule-buttons {
         padding: 12px 0;
 
-        a, a:hover, a:active, a:visited, a:focus {
+        a,
+        a:hover,
+        a:active,
+        a:visited,
+        a:focus {
           cursor: pointer;
           font-size: initial;
           text-decoration: none;

--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.ts
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.component.ts
@@ -5,14 +5,14 @@ import {
   Output,
   ViewEncapsulation,
   OnChanges,
-  ChangeDetectorRef,
+  ChangeDetectorRef
 } from '@angular/core';
 import { FormGroup, FormControl, FormArray } from '@angular/forms';
 import {
   DynamicFormService,
   DynamicFormControlModel,
   DynamicFormArrayModel,
-  DynamicInputModel,
+  DynamicInputModel
 } from '@ng-dynamic-forms/core';
 
 import { CurrentFlow, FlowEvent } from '../../current-flow.service';
@@ -27,7 +27,7 @@ import { BasicFilter } from './filter.interface';
   selector: 'syndesis-basic-filter',
   templateUrl: './basic-filter.component.html',
   encapsulation: ViewEncapsulation.None,
-  styleUrls: ['./basic-filter.component.scss'],
+  styleUrls: ['./basic-filter.component.scss']
 })
 export class BasicFilterComponent implements OnChanges {
   basicFilterModel: DynamicFormControlModel[];
@@ -50,14 +50,14 @@ export class BasicFilterComponent implements OnChanges {
     rules: [
       {
         path: 'body.text',
-        value: 'antman',
+        value: 'antman'
       },
       {
         path: 'header.kind',
         op: '=~',
-        value: 'DC Comics',
-      },
-    ],
+        value: 'DC Comics'
+      }
+    ]
   };
   @Output() configuredPropertiesChange = new EventEmitter<BasicFilter>();
   @Input() valid: boolean;
@@ -67,7 +67,7 @@ export class BasicFilterComponent implements OnChanges {
     public currentFlow: CurrentFlow,
     public integrationSupport: IntegrationSupportService,
     private formService: DynamicFormService,
-    private detector: ChangeDetectorRef,
+    private detector: ChangeDetectorRef
   ) {}
 
   ngOnChanges(changes: any) {
@@ -82,7 +82,7 @@ export class BasicFilterComponent implements OnChanges {
       self.basicFilterModel = createBasicFilterModel(
         self.configuredProperties || <any>{},
         ops,
-        paths,
+        paths
       );
       self.formGroup = self.formService.createFormGroup(self.basicFilterModel);
       self.predicateControl = self.formGroup
@@ -90,14 +90,14 @@ export class BasicFilterComponent implements OnChanges {
         .get('predicate') as FormControl;
       self.predicateModel = findById(
         'predicate',
-        self.basicFilterModel,
+        self.basicFilterModel
       ) as DynamicInputModel;
       self.rulesArrayControl = self.formGroup
         .get('rulesGroup')
         .get('rulesFormArray') as FormArray;
       self.rulesArrayModel = findById(
         'rulesFormArray',
-        self.basicFilterModel,
+        self.basicFilterModel
       ) as DynamicFormArrayModel;
       self.loading = false;
       self.detector.detectChanges();
@@ -128,7 +128,7 @@ export class BasicFilterComponent implements OnChanges {
       .catch(error => {
         try {
           log.infoc(
-            () => 'Failed to fetch filter form data: ' + JSON.parse(error),
+            () => 'Failed to fetch filter form data: ' + JSON.parse(error)
           );
         } catch (err) {
           log.infoc(() => 'Failed to fetch filter form data: ' + error);
@@ -142,7 +142,7 @@ export class BasicFilterComponent implements OnChanges {
   add() {
     this.formService.addFormArrayGroup(
       this.rulesArrayControl,
-      this.rulesArrayModel,
+      this.rulesArrayModel
     );
     this.valid = this.formGroup.valid;
     this.validChange.emit(this.valid);
@@ -152,7 +152,7 @@ export class BasicFilterComponent implements OnChanges {
     this.formService.removeFormArrayGroup(
       index,
       this.rulesArrayControl,
-      context,
+      context
     );
     this.valid = this.formGroup.valid;
     this.validChange.emit(this.valid);
@@ -169,7 +169,7 @@ export class BasicFilterComponent implements OnChanges {
     const formattedProperties: BasicFilter = {
       type: 'rule',
       predicate: formGroupObj.filterSettingsGroup.predicate,
-      rules: formGroupObj.rulesGroup.rulesFormArray,
+      rules: formGroupObj.rulesGroup.rulesFormArray
     };
 
     this.configuredPropertiesChange.emit(formattedProperties);

--- a/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.model.ts
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/basic-filter.model.ts
@@ -3,11 +3,17 @@ import {
   DynamicSelectModel,
   DynamicFormArrayModel,
   DynamicFormArrayGroupModel,
-  DynamicFormGroupModel,
+  DynamicFormGroupModel
 } from '@ng-dynamic-forms/core';
 import { Observable } from 'rxjs/Observable';
 
-import { BasicFilter, Rule, Op, getDefaultOps, convertOps } from './filter.interface';
+import {
+  BasicFilter,
+  Rule,
+  Op,
+  getDefaultOps,
+  convertOps
+} from './filter.interface';
 
 export function findById(id: string, model: any): any {
   switch (typeof model) {
@@ -34,8 +40,11 @@ export function findById(id: string, model: any): any {
   return false;
 }
 
-export function createBasicFilterModel(configuredProperties: BasicFilter, ops: Array<Op> = [], paths: Array<string> = []) {
-
+export function createBasicFilterModel(
+  configuredProperties: BasicFilter,
+  ops: Array<Op> = [],
+  paths: Array<string> = []
+) {
   if (!ops || !ops.length) {
     ops = getDefaultOps();
   } else {
@@ -51,53 +60,53 @@ export function createBasicFilterModel(configuredProperties: BasicFilter, ops: A
           maxLength: 51,
           required: true,
           validators: {
-            required: null,
+            required: null
           },
           errorMessages: {
-            required: 'Object property name is required',
+            required: 'Object property name is required'
           },
           //placeholder: paths.length ? paths[0] : 'Field Name',
           value: rule ? rule.path : undefined,
-          list: paths,
+          list: paths
           //suffix: 'Browse...', // This is just a suffix; this whole field needs to change
         },
         {
           element: {
-            container: 'form-group col-xs-3',
+            container: 'form-group col-xs-3'
           },
           grid: {
-            control: 'input-group',
-          },
-        },
+            control: 'input-group'
+          }
+        }
       ),
       new DynamicSelectModel<string>(
         {
           id: 'op',
           value: rule ? rule.op : 'contains',
-          options: Observable.of(<any> ops),
+          options: Observable.of(<any>ops)
         },
         {
           element: {
             container: 'form-group col-xs-3',
-            label: 'control-label',
+            label: 'control-label'
           },
           grid: {
-            control: 'input-group',
-          },
-        },
+            control: 'input-group'
+          }
+        }
       ),
       new DynamicInputModel(
         {
           id: 'value',
           value: rule ? rule.value : undefined,
-          placeholder: 'Keywords...',
+          placeholder: 'Keywords...'
         },
         {
           grid: {
-            container: 'input-group col-xs-4 keywords',
-          },
-        },
-      ),
+            container: 'input-group col-xs-4 keywords'
+          }
+        }
+      )
     ];
   }
   let groups = undefined;
@@ -113,7 +122,7 @@ export function createBasicFilterModel(configuredProperties: BasicFilter, ops: A
     groups = [];
     for (const rule of rules) {
       groups.push(
-        new DynamicFormArrayGroupModel(undefined, groupFactory(rule)),
+        new DynamicFormArrayGroupModel(undefined, groupFactory(rule))
       );
     }
   }
@@ -128,25 +137,25 @@ export function createBasicFilterModel(configuredProperties: BasicFilter, ops: A
             options: Observable.of([
               {
                 label: 'ALL of the following',
-                value: 'AND',
+                value: 'AND'
               },
               {
                 label: 'ANY of the following',
-                value: 'OR',
-              },
+                value: 'OR'
+              }
             ]),
-            value: configuredProperties.predicate || 'AND',
+            value: configuredProperties.predicate || 'AND'
           },
           {
             element: {
-              label: 'control-label pull-left',
+              label: 'control-label pull-left'
             },
             grid: {
-              control: 'col-xs-3 match-select',
-            },
-          },
-        ),
-      ],
+              control: 'col-xs-3 match-select'
+            }
+          }
+        )
+      ]
     }),
 
     new DynamicFormGroupModel({
@@ -157,16 +166,16 @@ export function createBasicFilterModel(configuredProperties: BasicFilter, ops: A
             id: 'rulesFormArray',
             groups: groups,
             initialCount: rules ? rules.length : 1,
-            groupFactory: groupFactory,
+            groupFactory: groupFactory
           },
           {
             element: {
-              container: 'form-inline form-array rules-group',
-            },
-          },
-        ),
-      ],
-    }),
+              container: 'form-inline form-array rules-group'
+            }
+          }
+        )
+      ]
+    })
   ];
   return answer;
 }

--- a/src/app/integrations/edit-page/step-configure/filter-steps/filter.interface.ts
+++ b/src/app/integrations/edit-page/step-configure/filter-steps/filter.interface.ts
@@ -24,7 +24,7 @@ export function convertOps(ops: Array<Op>): Array<Op> {
     const label = op.label === '' ? op.value || op.operator : op.label;
     const newOp = {
       label: label,
-      value: op.value || op.operator,
+      value: op.value || op.operator
     };
     answer.push(newOp);
   }
@@ -35,27 +35,27 @@ export function getDefaultOps(): Array<Op> {
   return [
     {
       label: 'Contains',
-      value: 'contains',
+      value: 'contains'
     },
     {
       label: 'Does Not Contain',
-      value: 'not contains',
+      value: 'not contains'
     },
     {
       label: 'Matches Regex',
-      value: 'regex',
+      value: 'regex'
     },
     {
       label: 'Does Not Match Regex',
-      value: 'not regex',
+      value: 'not regex'
     },
     {
       label: 'Starts With',
-      value: 'starts with',
+      value: 'starts with'
     },
     {
       label: 'Ends With',
-      value: 'ends with',
-    },
+      value: 'ends with'
+    }
   ];
 }

--- a/src/app/integrations/edit-page/step-configure/step-configure.component.ts
+++ b/src/app/integrations/edit-page/step-configure/step-configure.component.ts
@@ -3,21 +3,21 @@ import {
   Input,
   OnInit,
   OnDestroy,
-  ChangeDetectorRef,
+  ChangeDetectorRef
 } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 import { ActivatedRoute, ParamMap, Router } from '@angular/router';
 import { FormGroup } from '@angular/forms';
 import {
   DynamicFormControlModel,
-  DynamicFormService,
+  DynamicFormService
 } from '@ng-dynamic-forms/core';
 
 import { FlowPage } from '../flow-page';
 import {
   StepStore,
   DATA_MAPPER,
-  BASIC_FILTER,
+  BASIC_FILTER
 } from '../../../store/step/step.store';
 import { FormFactoryService } from '../../../common/forms.service';
 import { CurrentFlow, FlowEvent } from '../current-flow.service';
@@ -30,7 +30,7 @@ const category = getCategory('IntegrationsCreatePage');
 @Component({
   selector: 'syndesis-integrations-step-configure',
   templateUrl: './step-configure.component.html',
-  styleUrls: ['./step-configure.component.scss'],
+  styleUrls: ['./step-configure.component.scss']
 })
 export class IntegrationsStepConfigureComponent extends FlowPage
   implements OnInit, OnDestroy {
@@ -58,7 +58,7 @@ export class IntegrationsStepConfigureComponent extends FlowPage
     public formService: DynamicFormService,
     public detector: ChangeDetectorRef,
     public stepStore: StepStore,
-    public integrationSupport: IntegrationSupportService,
+    public integrationSupport: IntegrationSupportService
   ) {
     super(currentFlow, route, router, detector);
   }
@@ -84,7 +84,7 @@ export class IntegrationsStepConfigureComponent extends FlowPage
     if (step.stepKind === DATA_MAPPER) {
       this.router.navigate(['save-or-add-step'], {
         queryParams: { validate: true },
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
       return;
     }
@@ -104,9 +104,9 @@ export class IntegrationsStepConfigureComponent extends FlowPage
       onSave: () => {
         this.router.navigate(['save-or-add-step'], {
           queryParams: { validate: true },
-          relativeTo: this.route.parent,
+          relativeTo: this.route.parent
         });
-      },
+      }
     });
   }
 
@@ -142,7 +142,7 @@ export class IntegrationsStepConfigureComponent extends FlowPage
     }
     this.currentFlow.events.emit({
       kind: 'integration-action-configure',
-      position: this.position,
+      position: this.position
     });
   }
 
@@ -151,7 +151,7 @@ export class IntegrationsStepConfigureComponent extends FlowPage
       .fetchMetadata(
         step.connection,
         step.action,
-        step.configuredProperties || {},
+        step.configuredProperties || {}
       )
       .toPromise()
       .then(response => {
@@ -170,13 +170,13 @@ export class IntegrationsStepConfigureComponent extends FlowPage
         const error = JSON.parse(response['_body']);
         this.error = {
           class: 'alert alert-warning',
-          message: error.message || error.userMsg || error.developerMsg,
+          message: error.message || error.userMsg || error.developerMsg
         };
         log.info(
           'Error fetching data shape for ' +
             JSON.stringify(step) +
             ' : ' +
-            JSON.stringify(response),
+            JSON.stringify(response)
         );
         this.detector.detectChanges();
       });
@@ -191,18 +191,18 @@ export class IntegrationsStepConfigureComponent extends FlowPage
     // If no Step exists, redirect to the Select Step view
     if (!step) {
       this.router.navigate(['step-select', this.position], {
-        relativeTo: this.route.parent,
+        relativeTo: this.route.parent
       });
       return;
     }
 
     // we want the output shape of the previous connection
     const prevConnection = this.currentFlow.getPreviousConnection(
-      this.position,
+      this.position
     );
     // we want the input shape of the next connection
     const nextConnection = this.currentFlow.getSubsequentConnection(
-      this.position,
+      this.position
     );
 
     this.fetchDataShapesFor(prevConnection, true)
@@ -222,7 +222,7 @@ export class IntegrationsStepConfigureComponent extends FlowPage
     // Now check if we've a custom view for this step kind
     if (this.stepStore.isCustomStep(step)) {
       this.customProperties = this.getConfiguredProperties(
-        step.configuredProperties || {},
+        step.configuredProperties || {}
       );
       this.postEvent();
       return;
@@ -235,7 +235,7 @@ export class IntegrationsStepConfigureComponent extends FlowPage
     const values: any = this.getConfiguredProperties(step.configuredProperties);
     log.info(
       'Form config: ' + JSON.stringify(this.formConfig, undefined, 2),
-      category,
+      category
     );
 
     // Call formService to build the form
@@ -259,7 +259,7 @@ export class IntegrationsStepConfigureComponent extends FlowPage
       (paramMap: ParamMap) => {
         this.position = +paramMap.get('position');
         this.loadForm();
-      },
+      }
     );
   }
 

--- a/src/app/integrations/edit-page/step-select/step-select.component.ts
+++ b/src/app/integrations/edit-page/step-select/step-select.component.ts
@@ -11,7 +11,7 @@ import { log, getCategory } from '../../../logging';
 @Component({
   selector: 'syndesis-integrations-step-select',
   templateUrl: './step-select.component.html',
-  styleUrls: ['./step-select.component.scss'],
+  styleUrls: ['./step-select.component.scss']
 })
 export class IntegrationsStepSelectComponent extends FlowPage
   implements OnInit {
@@ -24,7 +24,7 @@ export class IntegrationsStepSelectComponent extends FlowPage
     public route: ActivatedRoute,
     public router: Router,
     public stepStore: StepStore,
-    public detector: ChangeDetectorRef,
+    public detector: ChangeDetectorRef
   ) {
     super(currentFlow, route, router, detector);
     this.steps = stepStore.getSteps();
@@ -58,13 +58,13 @@ export class IntegrationsStepSelectComponent extends FlowPage
         if (!step) {
           // safety net
           this.router.navigate(['save-or-add-step'], {
-            relativeTo: this.route.parent,
+            relativeTo: this.route.parent
           });
           return;
         }
         if (step.configuredProperties) {
           this.router.navigate(['step-configure', this.position], {
-            relativeTo: this.route.parent,
+            relativeTo: this.route.parent
           });
           return;
         }
@@ -91,9 +91,9 @@ export class IntegrationsStepSelectComponent extends FlowPage
       step: step,
       onSave: () => {
         this.router.navigate(['step-configure', this.position], {
-          relativeTo: this.route.parent,
+          relativeTo: this.route.parent
         });
-      },
+      }
     });
   }
 
@@ -104,7 +104,7 @@ export class IntegrationsStepSelectComponent extends FlowPage
         this.position = Number.parseInt(position);
         this.currentFlow.events.emit({
           kind: 'integration-step-select',
-          position: this.position,
+          position: this.position
         });
       })
       .subscribe();

--- a/src/app/integrations/edit-page/step-select/step-visible.pipe.ts
+++ b/src/app/integrations/edit-page/step-select/step-visible.pipe.ts
@@ -9,12 +9,10 @@ export class StepVisibleConfig {
 
 @Pipe({
   name: 'stepVisible',
-  pure: false,
+  pure: false
 })
 export class StepVisiblePipe implements PipeTransform {
-  constructor(
-    private currentFlow: CurrentFlow,
-  ) {}
+  constructor(private currentFlow: CurrentFlow) {}
   transform(objects: Array<StepKind>, config: StepVisibleConfig) {
     if (!this.currentFlow.loaded) {
       return false;

--- a/src/app/integrations/integrations.module.ts
+++ b/src/app/integrations/integrations.module.ts
@@ -7,7 +7,7 @@ import {
   CollapseModule,
   ModalModule,
   PopoverModule,
-  TabsModule,
+  TabsModule
 } from 'ngx-bootstrap';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { DataMapperModule } from '@atlasmap/atlasmap.data.mapper';
@@ -41,25 +41,25 @@ const editIntegrationChildRoutes = [
   { path: 'integration-basics', component: IntegrationBasicsComponent },
   {
     path: 'connection-select/:position',
-    component: IntegrationsSelectConnectionComponent,
+    component: IntegrationsSelectConnectionComponent
   },
   {
     path: 'action-select/:position',
-    component: IntegrationsSelectActionComponent,
+    component: IntegrationsSelectActionComponent
   },
   {
     path: 'action-configure/:position/:page',
-    component: IntegrationsConfigureActionComponent,
+    component: IntegrationsConfigureActionComponent
   },
   {
     path: 'action-configure/:position',
-    component: IntegrationsConfigureActionComponent,
+    component: IntegrationsConfigureActionComponent
   },
   { path: 'step-select/:position', component: IntegrationsStepSelectComponent },
   {
     path: 'step-configure/:position',
-    component: IntegrationsStepConfigureComponent,
-  },
+    component: IntegrationsStepConfigureComponent
+  }
 ];
 
 const routes: Routes = [
@@ -67,17 +67,17 @@ const routes: Routes = [
   {
     path: 'create',
     component: IntegrationsEditPage,
-    children: editIntegrationChildRoutes,
+    children: editIntegrationChildRoutes
   },
   {
     path: ':integrationId',
-    component: IntegrationsDetailComponent,
+    component: IntegrationsDetailComponent
   },
   {
     path: ':integrationId/edit',
     component: IntegrationsEditPage,
-    children: editIntegrationChildRoutes,
-  },
+    children: editIntegrationChildRoutes
+  }
 ];
 
 @NgModule({
@@ -97,7 +97,7 @@ const routes: Routes = [
     ModalModule,
     PopoverModule,
     DataMapperModule,
-    FileUploadModule,
+    FileUploadModule
   ],
   declarations: [
     DataMapperHostComponent,
@@ -118,9 +118,8 @@ const routes: Routes = [
     FlowViewStepComponent,
     ListActionsComponent,
     StepVisiblePipe,
-    CancelAddStepComponent,
+    CancelAddStepComponent
   ],
-  providers: [ CurrentFlow ],
+  providers: [CurrentFlow]
 })
-export class IntegrationsModule {
-}
+export class IntegrationsModule {}

--- a/src/app/integrations/list-page/list-page.component.spec.ts
+++ b/src/app/integrations/list-page/list-page.component.spec.ts
@@ -33,11 +33,9 @@ xdescribe('IntegrationsListPage', () => {
           TabsModule.forRoot(),
           NotificationModule,
           PatternflyUIModule,
-          IntegrationsListModule,
+          IntegrationsListModule
         ],
-        declarations: [
-          IntegrationsListPage,
-        ],
+        declarations: [IntegrationsListPage],
         providers: [
           MockBackend,
           { provide: RequestOptions, useClass: BaseRequestOptions },
@@ -46,11 +44,11 @@ xdescribe('IntegrationsListPage', () => {
             useFactory: (backend, options) => {
               return new Http(backend, options);
             },
-            deps: [MockBackend, RequestOptions],
-          },
-        ],
+            deps: [MockBackend, RequestOptions]
+          }
+        ]
       }).compileComponents();
-    }),
+    })
   );
 
   beforeEach(() => {

--- a/src/app/integrations/list-page/list-page.component.ts
+++ b/src/app/integrations/list-page/list-page.component.ts
@@ -3,69 +3,88 @@ import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
-import { FilterField, NotificationService, NotificationType } from 'patternfly-ng';
+import {
+  FilterField,
+  NotificationService,
+  NotificationType
+} from 'patternfly-ng';
 
 import { IntegrationStore } from '../../store/integration/integration.store';
 import { Integrations } from '../../model';
 import { ModalService } from '../../common/modal/modal.service';
 import { IntegrationSupportService } from '../../store/integration-support.service';
-import { FileUploader, FileItem, ParsedResponseHeaders } from 'ng2-file-upload-base/src';
+import {
+  FileUploader,
+  FileItem,
+  ParsedResponseHeaders
+} from 'ng2-file-upload-base/src';
 
 @Component({
   selector: 'syndesis-integrations-list-page',
   templateUrl: './list-page.component.html',
-  styleUrls: ['./list-page.component.scss'],
+  styleUrls: ['./list-page.component.scss']
 })
 export class IntegrationsListPage implements OnInit {
-
   public uploader: FileUploader;
 
   loading: Observable<boolean>;
   integrations: Observable<Integrations>;
-  filteredIntegrations: Subject<Integrations> = new BehaviorSubject(<Integrations>{});
-  filterFields: Array<FilterField> = [{
-    id: 'currentStatus',
-    title: 'State',
-    type: 'select',
-    placeholder: 'Filter by state...',
-    queries: [
-      { id: 'actived', value: 'Activated' },
-      { id: 'deactivated', value: 'Deactivated' },
-      { id: 'draft', value: 'Draft' },
-    ],
-  }];
+  filteredIntegrations: Subject<
+    Integrations
+  > = new BehaviorSubject(<Integrations>{});
+  filterFields: Array<FilterField> = [
+    {
+      id: 'currentStatus',
+      title: 'State',
+      type: 'select',
+      placeholder: 'Filter by state...',
+      queries: [
+        { id: 'actived', value: 'Activated' },
+        { id: 'deactivated', value: 'Deactivated' },
+        { id: 'draft', value: 'Draft' }
+      ]
+    }
+  ];
 
   constructor(
     private store: IntegrationStore,
     private modalService: ModalService,
     private integrationSupportService: IntegrationSupportService,
     public notificationService: NotificationService,
-    public application: ApplicationRef,
+    public application: ApplicationRef
   ) {
     this.integrations = this.store.list;
     this.loading = this.store.loading;
     this.uploader = new FileUploader({
       url: integrationSupportService.importIntegrationURL(),
       disableMultipart: true,
-      autoUpload: true,
+      autoUpload: true
     });
-    this.uploader.onCompleteItem = (item: FileItem, response: string, status: number, headers: ParsedResponseHeaders) => {
-      if ( status === 204 ) {
+    this.uploader.onCompleteItem = (
+      item: FileItem,
+      response: string,
+      status: number,
+      headers: ParsedResponseHeaders
+    ) => {
+      if (status === 204) {
         this.notificationService.message(
           NotificationType.SUCCESS,
           'Imported!',
           'Your integration has been imported',
-          false, null, [],
+          false,
+          null,
+          []
         );
       } else {
         this.notificationService.message(
           NotificationType.DANGER,
           'Import Failed!',
           'Your integration could not be imported.',
-          false, null, [],
+          false,
+          null,
+          []
         );
       }
-
     };
   }
 
@@ -81,5 +100,4 @@ export class IntegrationsListPage implements OnInit {
       this.uploader.clearQueue();
     });
   }
-
 }

--- a/src/app/integrations/list/list.component.spec.ts
+++ b/src/app/integrations/list/list.component.spec.ts
@@ -32,11 +32,11 @@ xdescribe('IntegrationsListComponent', () => {
           StoreModule,
           ActionModule,
           ListModule,
-          NotificationModule,
+          NotificationModule
         ],
-        declarations: [IntegrationStatusComponent, IntegrationsListComponent],
+        declarations: [IntegrationStatusComponent, IntegrationsListComponent]
       }).compileComponents();
-    }),
+    })
   );
 
   beforeEach(() => {

--- a/src/app/integrations/list/list.component.ts
+++ b/src/app/integrations/list/list.component.ts
@@ -11,7 +11,7 @@ import {
   EmptyStateConfig,
   Notification,
   NotificationService,
-  NotificationType,
+  NotificationType
 } from 'patternfly-ng';
 
 import { Integrations, Integration } from '../../model';
@@ -23,7 +23,7 @@ import { log, getCategory } from '../../logging';
 @Component({
   selector: 'syndesis-integrations-list',
   templateUrl: './list.component.html',
-  styleUrls: ['./list.component.scss'],
+  styleUrls: ['./list.component.scss']
 })
 export class IntegrationsListComponent extends IntegrationViewBase {
   @Input() complete: boolean;
@@ -36,7 +36,7 @@ export class IntegrationsListComponent extends IntegrationViewBase {
     public router: Router,
     public notificationService: NotificationService,
     public modalService: ModalService,
-    public application: ApplicationRef,
+    public application: ApplicationRef
   ) {
     super(store, route, router, notificationService, modalService, application);
     this.listConfig = {
@@ -47,16 +47,19 @@ export class IntegrationsListComponent extends IntegrationViewBase {
       emptyStateConfig: {
         iconStyleClass: 'pficon pficon-add-circle-o',
         title: 'Create an integration',
-        info: 'There are currently no integrations available. Please click on the button below to create one.',
+        info:
+          'There are currently no integrations available. Please click on the button below to create one.',
         actions: {
-          primaryActions: [{
-            id: 'createIntegration',
-            title: 'Create Integration',
-            tooltip: 'create an integration',
-          }],
-          moreActions: [],
-        } as ActionConfig,
-      } as EmptyStateConfig,
+          primaryActions: [
+            {
+              id: 'createIntegration',
+              title: 'Create Integration',
+              tooltip: 'create an integration'
+            }
+          ],
+          moreActions: []
+        } as ActionConfig
+      } as EmptyStateConfig
     };
   }
 
@@ -68,7 +71,7 @@ export class IntegrationsListComponent extends IntegrationViewBase {
 
   handleClick($event: ListEvent) {
     this.router.navigate(['/integrations', $event.item.id], {
-      relativeTo: this.route,
+      relativeTo: this.route
     });
   }
 
@@ -80,35 +83,35 @@ export class IntegrationsListComponent extends IntegrationViewBase {
           id: 'view',
           title: 'View',
           tooltip: `View ${integration.name}`,
-          visible: true,
+          visible: true
         },
         {
           id: 'edit',
           title: 'Edit',
           tooltip: `Edit ${integration.name}`,
-          visible: this.canEdit(integration),
+          visible: this.canEdit(integration)
         },
         {
           id: 'activate',
           title: 'Activate',
           tooltip: `Activate ${integration.name}`,
-          visible: this.canActivate(integration),
+          visible: this.canActivate(integration)
         },
         {
           id: 'deactivate',
           title: 'Deactivate',
           tooltip: `Deactivate ${integration.name}`,
-          visible: this.canDeactivate(integration),
+          visible: this.canDeactivate(integration)
         },
         {
           id: 'delete',
           title: 'Delete',
           tooltip: `Delete ${integration.name}`,
-          visible: this.canDelete(integration),
-        },
+          visible: this.canDelete(integration)
+        }
       ],
       moreActionsDisabled: false,
-      moreActionsVisible: true,
+      moreActionsVisible: true
     } as ActionConfig;
 
     // Hide kebab

--- a/src/app/integrations/list/list.module.ts
+++ b/src/app/integrations/list/list.module.ts
@@ -13,16 +13,9 @@ import { IntegrationsListComponent } from './list.component';
     CommonModule,
     ListModule,
     SyndesisCommonModule,
-    TooltipModule,
+    TooltipModule
   ],
-  declarations: [
-    IntegrationStatusComponent,
-    IntegrationsListComponent,
-  ],
-  exports: [
-    IntegrationsListComponent,
-    IntegrationStatusComponent,
-  ],
+  declarations: [IntegrationStatusComponent, IntegrationsListComponent],
+  exports: [IntegrationsListComponent, IntegrationStatusComponent]
 })
-export class IntegrationsListModule {
-}
+export class IntegrationsListModule {}

--- a/src/app/logging.ts
+++ b/src/app/logging.ts
@@ -3,7 +3,7 @@ import {
   CategoryLogger,
   CategoryServiceFactory,
   CategoryDefaultConfiguration,
-  LogLevel,
+  LogLevel
 } from 'typescript-logging';
 
 // TODO typescript-logging will support a console API to change this at runtime in the future, for now we'll use localStorage
@@ -13,7 +13,7 @@ const logLevel = LogLevel[storedLogLevel] || LogLevel.Info;
 
 // default configuration
 CategoryServiceFactory.setDefaultConfiguration(
-  new CategoryDefaultConfiguration(logLevel),
+  new CategoryDefaultConfiguration(logLevel)
 );
 
 const rootCategory = new Category('root');
@@ -31,5 +31,5 @@ export function getCategory(name: string) {
 
 // files should import this logger instance
 export const log: CategoryLogger = CategoryServiceFactory.getLogger(
-  rootCategory,
+  rootCategory
 );

--- a/src/app/model.ts
+++ b/src/app/model.ts
@@ -1,618 +1,601 @@
 /* tslint:disable */
 
 export interface BaseEntity {
-    readonly id ? : string;
-    // TODO we'll make this optional for now
-    kind ? : string;
+  readonly id?: string;
+  // TODO we'll make this optional for now
+  kind?: string;
 }
 
 // TODO local hack to avoid deleting all the related code
-export interface IntegrationTemplate extends BaseEntity {
-
-}
+export interface IntegrationTemplate extends BaseEntity {}
 export type IntegrationTemplates = Array<IntegrationTemplate>;
 
 export interface Action extends BaseEntity {
-    definition: ActionDefinition;
-    camelConnectorPrefix: string;
-    connectorId: string;
-    description: string;
-    camelConnectorGAV: string;
-    id: string;
-    name: string;
-    tags: Array < string >
-    ;
-    // TODO DEPRECATED?
-    outputDataShape: DataShape;
-    inputDataShape: DataShape;
-};
-export type Actions = Array < Action > ;
+  definition: ActionDefinition;
+  camelConnectorPrefix: string;
+  connectorId: string;
+  description: string;
+  camelConnectorGAV: string;
+  id: string;
+  name: string;
+  tags: Array<string>;
+  // TODO DEPRECATED?
+  outputDataShape: DataShape;
+  inputDataShape: DataShape;
+}
+export type Actions = Array<Action>;
 
 export interface ActionDefinition extends BaseEntity {
-    outputDataShape: DataShape;
-    propertyDefinitionSteps: Array < ActionDefinitionStep >
-    ;
-    inputDataShape: DataShape;
-};
-export type ActionDefinitions = Array < ActionDefinition > ;
+  outputDataShape: DataShape;
+  propertyDefinitionSteps: Array<ActionDefinitionStep>;
+  inputDataShape: DataShape;
+}
+export type ActionDefinitions = Array<ActionDefinition>;
 
 export interface ActionDefinitionStep extends BaseEntity {
-    description: string;
-    name: string;
-    properties: {};
-    configuredProperties: {};
-};
-export type ActionDefinitionSteps = Array < ActionDefinitionStep > ;
+  description: string;
+  name: string;
+  properties: {};
+  configuredProperties: {};
+}
+export type ActionDefinitionSteps = Array<ActionDefinitionStep>;
 
 export interface ConfigurationProperty extends BaseEntity {
-    javaType: string;
-    type: string;
-    defaultValue: string;
-    displayName: string;
-    kind: string;
-    description: string;
-    group: string;
-    required: boolean;
-    secret: boolean;
-    label: string;
-    enum: Array < PropertyValue >
-    ;
-    componentProperty: boolean;
-    deprecated: boolean;
-    tags: Array < string >
-    ;
-};
-export type ConfigurationProperties = Array < ConfigurationProperty > ;
+  javaType: string;
+  type: string;
+  defaultValue: string;
+  displayName: string;
+  kind: string;
+  description: string;
+  group: string;
+  required: boolean;
+  secret: boolean;
+  label: string;
+  enum: Array<PropertyValue>;
+  componentProperty: boolean;
+  deprecated: boolean;
+  tags: Array<string>;
+}
+export type ConfigurationProperties = Array<ConfigurationProperty>;
 
 export interface Connection extends BaseEntity {
-    icon: string;
-    organization: Organization;
-    configuredProperties: {};
-    organizationId: string;
-    connectorId: string;
-    options: {};
-    description: string;
-    connector: Connector;
-    derived: boolean;
-    userId: string;
-    lastUpdated: string;
-    createdDate: string;
-    id: string;
-    tags: Array < string >
-    ;
-    name: string;
-};
-export type Connections = Array < Connection > ;
+  icon: string;
+  organization: Organization;
+  configuredProperties: {};
+  organizationId: string;
+  connectorId: string;
+  options: {};
+  description: string;
+  connector: Connector;
+  derived: boolean;
+  userId: string;
+  lastUpdated: string;
+  createdDate: string;
+  id: string;
+  tags: Array<string>;
+  name: string;
+}
+export type Connections = Array<Connection>;
 
 export interface Connector extends BaseEntity {
-    icon: string;
-    properties: {};
-    actions: Array < Action >
-    ;
-    connectorGroupId: string;
-    configuredProperties: {};
-    description: string;
-    connectorGroup: ConnectorGroup;
-    id: string;
-    name: string;
-};
-export type Connectors = Array < Connector > ;
+  icon: string;
+  properties: {};
+  actions: Array<Action>;
+  connectorGroupId: string;
+  configuredProperties: {};
+  description: string;
+  connectorGroup: ConnectorGroup;
+  id: string;
+  name: string;
+}
+export type Connectors = Array<Connector>;
 
 export interface ConnectorGroup extends BaseEntity {
-    id: string;
-    name: string;
-};
-export type ConnectorGroups = Array < ConnectorGroup > ;
+  id: string;
+  name: string;
+}
+export type ConnectorGroups = Array<ConnectorGroup>;
 
 export interface DataShape extends BaseEntity {
-    specification: string;
-    exemplar: Array < string >
-    ;
-    type: string;
-    kind: string;
-};
-export type DataShapes = Array < DataShape > ;
+  specification: string;
+  exemplar: Array<string>;
+  type: string;
+  kind: string;
+}
+export type DataShapes = Array<DataShape>;
 
 export interface Environment extends BaseEntity {
-    id: string;
-    name: string;
-};
-export type Environments = Array < Environment > ;
+  id: string;
+  name: string;
+}
+export type Environments = Array<Environment>;
 
 export interface Integration extends BaseEntity {
-    configuration: string;
-    description: string;
-    deployedRevisionId: number;
-    revisions: Array < IntegrationRevision >
-    ;
-    statusMessage: string;
-    token: string;
-    steps: Array < Step >
-    ;
-    draftRevision: IntegrationRevision;
-    gitRepo: string;
-    users: Array < User >
-    ;
-    connections: Array < Connection >
-    ;
-    userId: string;
-    desiredStatus: "Draft" | "Pending" | "Activated" | "Deactivated" | "Deleted";
-    currentStatus: "Draft" | "Pending" | "Activated" | "Deactivated" | "Deleted";
-    stepsDone: Array < string >
-    ;
-    lastUpdated: string;
-    createdDate: string;
-    timesUsed: number;
-    integrationTemplateId: string;
-    id: string;
-    tags: Array < string >
-    ;
-    name: string;
-};
-export type Integrations = Array < Integration > ;
+  configuration: string;
+  description: string;
+  deployedRevisionId: number;
+  revisions: Array<IntegrationRevision>;
+  statusMessage: string;
+  token: string;
+  steps: Array<Step>;
+  draftRevision: IntegrationRevision;
+  gitRepo: string;
+  users: Array<User>;
+  connections: Array<Connection>;
+  userId: string;
+  desiredStatus: 'Draft' | 'Pending' | 'Activated' | 'Deactivated' | 'Deleted';
+  currentStatus: 'Draft' | 'Pending' | 'Activated' | 'Deactivated' | 'Deleted';
+  stepsDone: Array<string>;
+  lastUpdated: string;
+  createdDate: string;
+  timesUsed: number;
+  integrationTemplateId: string;
+  id: string;
+  tags: Array<string>;
+  name: string;
+}
+export type Integrations = Array<Integration>;
 
 export interface IntegrationRevision extends BaseEntity {
-    currentMessage: string;
-    parentVersion: number;
-    targetState: "Draft" | "Active" | "Inactive" | "Undeployed" | "Error" | "Pending";
-    targetMessage: string;
-    version: number;
-    spec: IntegrationRevisionSpec;
-    currentState: "Draft" | "Active" | "Inactive" | "Undeployed" | "Error" | "Pending";
-};
-export type IntegrationRevisions = Array < IntegrationRevision > ;
+  currentMessage: string;
+  parentVersion: number;
+  targetState:
+    | 'Draft'
+    | 'Active'
+    | 'Inactive'
+    | 'Undeployed'
+    | 'Error'
+    | 'Pending';
+  targetMessage: string;
+  version: number;
+  spec: IntegrationRevisionSpec;
+  currentState:
+    | 'Draft'
+    | 'Active'
+    | 'Inactive'
+    | 'Undeployed'
+    | 'Error'
+    | 'Pending';
+}
+export type IntegrationRevisions = Array<IntegrationRevision>;
 
 export interface IntegrationRevisionSpec extends BaseEntity {
-    configuration: string;
-    steps: Array < Step >
-    ;
-    connections: Array < Connection >
-    ;
-};
-export type IntegrationRevisionSpecs = Array < IntegrationRevisionSpec > ;
+  configuration: string;
+  steps: Array<Step>;
+  connections: Array<Connection>;
+}
+export type IntegrationRevisionSpecs = Array<IntegrationRevisionSpec>;
 
 export interface Organization extends BaseEntity {
-    environments: Array < Environment >
-    ;
-    users: Array < User >
-    ;
-    id: string;
-    name: string;
-};
-export type Organizations = Array < Organization > ;
+  environments: Array<Environment>;
+  users: Array<User>;
+  id: string;
+  name: string;
+}
+export type Organizations = Array<Organization>;
 
 export interface PropertyValue extends BaseEntity {
-    value: string;
-    label: string;
-};
-export type PropertyValues = Array < PropertyValue > ;
+  value: string;
+  label: string;
+}
+export type PropertyValues = Array<PropertyValue>;
 
 export interface Step extends BaseEntity {
-    action: Action;
-    connection: Connection;
-    name: string;
-    configuredProperties: {};
-    stepKind: string;
-    id: string;
-};
-export type Steps = Array < Step > ;
+  action: Action;
+  connection: Connection;
+  name: string;
+  configuredProperties: {};
+  stepKind: string;
+  id: string;
+}
+export type Steps = Array<Step>;
 
 export interface User extends BaseEntity {
-    fullName: string;
-    name: string;
-    organizationId: string;
-    username: string;
-    firstName: string;
-    lastName: string;
-    integrations: Array < Integration >
-    ;
-    roleId: string;
-    id: string;
-};
-export type Users = Array < User > ;
+  fullName: string;
+  name: string;
+  organizationId: string;
+  username: string;
+  firstName: string;
+  lastName: string;
+  integrations: Array<Integration>;
+  roleId: string;
+  id: string;
+}
+export type Users = Array<User>;
 
 export interface ListResult extends BaseEntity {
-    items: Array < {} >
-    ;
-    totalCount: number;
-};
-export type ListResults = Array < ListResult > ;
+  items: Array<{}>;
+  totalCount: number;
+}
+export type ListResults = Array<ListResult>;
 
 export interface ListResultWithIdObject extends BaseEntity {
-    items: Array < WithIdObject >
-    ;
-    totalCount: number;
-};
-export type ListResultWithIdObjects = Array < ListResultWithIdObject > ;
+  items: Array<WithIdObject>;
+  totalCount: number;
+}
+export type ListResultWithIdObjects = Array<ListResultWithIdObject>;
 
 export interface WithId extends BaseEntity {
-    id: string;
-};
-export type WithIds = Array < WithId > ;
+  id: string;
+}
+export type WithIds = Array<WithId>;
 
 export interface WithIdObject extends BaseEntity {
-    id: string;
-};
-export type WithIdObjects = Array < WithIdObject > ;
+  id: string;
+}
+export type WithIdObjects = Array<WithIdObject>;
 
-export interface Violation extends BaseEntity {};
-export type Violations = Array < Violation > ;
+export interface Violation extends BaseEntity {}
+export type Violations = Array<Violation>;
 
 export interface ListResultAction extends BaseEntity {
-    items: Array < Action >
-    ;
-    totalCount: number;
-};
-export type ListResultActions = Array < ListResultAction > ;
+  items: Array<Action>;
+  totalCount: number;
+}
+export type ListResultActions = Array<ListResultAction>;
 
 export interface AcquisitionMethod extends BaseEntity {
-    icon: string;
-    type: "OAUTH1" | "OAUTH2";
-    description: string;
-    label: string;
-};
-export type AcquisitionMethods = Array < AcquisitionMethod > ;
+  icon: string;
+  type: 'OAUTH1' | 'OAUTH2';
+  description: string;
+  label: string;
+}
+export type AcquisitionMethods = Array<AcquisitionMethod>;
 
 export interface AcquisitionRequest extends BaseEntity {
-    returnUrl: string;
-};
-export type AcquisitionRequests = Array < AcquisitionRequest > ;
+  returnUrl: string;
+}
+export type AcquisitionRequests = Array<AcquisitionRequest>;
 
 export interface Error extends BaseEntity {
-    parameters: Array < string >
-    ;
-    attributes: {};
-    description: string;
-    code: string;
-};
-export type Errors = Array < Error > ;
+  parameters: Array<string>;
+  attributes: {};
+  description: string;
+  code: string;
+}
+export type Errors = Array<Error>;
 
 export interface Result extends BaseEntity {
-    scope: "PARAMETERS" | "CONNECTIVITY";
-    errors: Array < Error >
-    ;
-    status: "OK" | "ERROR" | "UNSUPPORTED";
-};
-export type Results = Array < Result > ;
+  scope: 'PARAMETERS' | 'CONNECTIVITY';
+  errors: Array<Error>;
+  status: 'OK' | 'ERROR' | 'UNSUPPORTED';
+}
+export type Results = Array<Result>;
 
 export interface FilterOptions extends BaseEntity {
-    paths: Array < string >
-    ;
-    ops: Array < Op >
-    ;
-};
-export type FilterOptionss = Array < FilterOptions > ;
+  paths: Array<string>;
+  ops: Array<Op>;
+}
+export type FilterOptionss = Array<FilterOptions>;
 
 export interface Op extends BaseEntity {
-    label: string;
-    operator: string;
-};
-export type Ops = Array < Op > ;
+  label: string;
+  operator: string;
+}
+export type Ops = Array<Op>;
 
 export interface EventMessage extends BaseEntity {
-    data: {};
-    event: string;
-};
-export type EventMessages = Array < EventMessage > ;
+  data: {};
+  event: string;
+}
+export type EventMessages = Array<EventMessage>;
 
 export interface OAuthApp extends BaseEntity {
-    id: string;
-    name: string;
-    icon: string;
-    clientId: string;
-    clientSecret: string;
-};
-export type OAuthApps = Array < OAuthApp > ;
+  id: string;
+  name: string;
+  icon: string;
+  clientId: string;
+  clientSecret: string;
+}
+export type OAuthApps = Array<OAuthApp>;
 
 export interface ListResultString extends BaseEntity {
-    items: Array < string >
-    ;
-    totalCount: number;
-};
-export type ListResultStrings = Array < ListResultString > ;
+  items: Array<string>;
+  totalCount: number;
+}
+export type ListResultStrings = Array<ListResultString>;
 
 class TypeFactoryClass {
-    createAction() {
-        return <Action > {
-            definition: undefined,
-            camelConnectorPrefix: undefined,
-            connectorId: undefined,
-            description: undefined,
-            camelConnectorGAV: undefined,
-            id: undefined,
-            name: undefined,
-            tags: undefined,
-        };
+  createAction() {
+    return <Action>{
+      definition: undefined,
+      camelConnectorPrefix: undefined,
+      connectorId: undefined,
+      description: undefined,
+      camelConnectorGAV: undefined,
+      id: undefined,
+      name: undefined,
+      tags: undefined
     };
+  }
 
-    createActionDefinition() {
-        return <ActionDefinition > {
-            outputDataShape: undefined,
-            propertyDefinitionSteps: undefined,
-            inputDataShape: undefined,
-        };
+  createActionDefinition() {
+    return <ActionDefinition>{
+      outputDataShape: undefined,
+      propertyDefinitionSteps: undefined,
+      inputDataShape: undefined
     };
+  }
 
-    createActionDefinitionStep() {
-        return <ActionDefinitionStep > {
-            description: undefined,
-            name: undefined,
-            properties: undefined,
-            configuredProperties: undefined,
-        };
+  createActionDefinitionStep() {
+    return <ActionDefinitionStep>{
+      description: undefined,
+      name: undefined,
+      properties: undefined,
+      configuredProperties: undefined
     };
+  }
 
-    createConfigurationProperty() {
-        return <ConfigurationProperty > {
-            javaType: undefined,
-            type: undefined,
-            defaultValue: undefined,
-            displayName: undefined,
-            kind: undefined,
-            description: undefined,
-            group: undefined,
-            required: undefined,
-            secret: undefined,
-            label: undefined,
-            enum: undefined,
-            componentProperty: undefined,
-            deprecated: undefined,
-            tags: undefined,
-        };
+  createConfigurationProperty() {
+    return <ConfigurationProperty>{
+      javaType: undefined,
+      type: undefined,
+      defaultValue: undefined,
+      displayName: undefined,
+      kind: undefined,
+      description: undefined,
+      group: undefined,
+      required: undefined,
+      secret: undefined,
+      label: undefined,
+      enum: undefined,
+      componentProperty: undefined,
+      deprecated: undefined,
+      tags: undefined
     };
+  }
 
-    createConnection() {
-        return <Connection > {
-            icon: undefined,
-            organization: undefined,
-            configuredProperties: undefined,
-            organizationId: undefined,
-            connectorId: undefined,
-            options: undefined,
-            description: undefined,
-            connector: undefined,
-            derived: undefined,
-            userId: undefined,
-            lastUpdated: undefined,
-            createdDate: undefined,
-            id: undefined,
-            tags: undefined,
-            name: undefined,
-        };
+  createConnection() {
+    return <Connection>{
+      icon: undefined,
+      organization: undefined,
+      configuredProperties: undefined,
+      organizationId: undefined,
+      connectorId: undefined,
+      options: undefined,
+      description: undefined,
+      connector: undefined,
+      derived: undefined,
+      userId: undefined,
+      lastUpdated: undefined,
+      createdDate: undefined,
+      id: undefined,
+      tags: undefined,
+      name: undefined
     };
+  }
 
-    createConnector() {
-        return <Connector > {
-            icon: undefined,
-            properties: undefined,
-            actions: undefined,
-            connectorGroupId: undefined,
-            configuredProperties: undefined,
-            description: undefined,
-            connectorGroup: undefined,
-            id: undefined,
-            name: undefined,
-        };
+  createConnector() {
+    return <Connector>{
+      icon: undefined,
+      properties: undefined,
+      actions: undefined,
+      connectorGroupId: undefined,
+      configuredProperties: undefined,
+      description: undefined,
+      connectorGroup: undefined,
+      id: undefined,
+      name: undefined
     };
+  }
 
-    createConnectorGroup() {
-        return <ConnectorGroup > {
-            id: undefined,
-            name: undefined,
-        };
+  createConnectorGroup() {
+    return <ConnectorGroup>{
+      id: undefined,
+      name: undefined
     };
+  }
 
-    createDataShape() {
-        return <DataShape > {
-            specification: undefined,
-            exemplar: undefined,
-            type: undefined,
-            kind: undefined,
-        };
+  createDataShape() {
+    return <DataShape>{
+      specification: undefined,
+      exemplar: undefined,
+      type: undefined,
+      kind: undefined
     };
+  }
 
-    createEnvironment() {
-        return <Environment > {
-            id: undefined,
-            name: undefined,
-        };
+  createEnvironment() {
+    return <Environment>{
+      id: undefined,
+      name: undefined
     };
+  }
 
-    createIntegration() {
-        return <Integration > {
-            configuration: undefined,
-            description: undefined,
-            deployedRevisionId: undefined,
-            revisions: undefined,
-            statusMessage: undefined,
-            token: undefined,
-            steps: undefined,
-            draftRevision: undefined,
-            gitRepo: undefined,
-            users: undefined,
-            connections: undefined,
-            userId: undefined,
-            desiredStatus: undefined,
-            currentStatus: undefined,
-            stepsDone: undefined,
-            lastUpdated: undefined,
-            createdDate: undefined,
-            timesUsed: undefined,
-            integrationTemplateId: undefined,
-            id: undefined,
-            tags: undefined,
-            name: undefined,
-        };
+  createIntegration() {
+    return <Integration>{
+      configuration: undefined,
+      description: undefined,
+      deployedRevisionId: undefined,
+      revisions: undefined,
+      statusMessage: undefined,
+      token: undefined,
+      steps: undefined,
+      draftRevision: undefined,
+      gitRepo: undefined,
+      users: undefined,
+      connections: undefined,
+      userId: undefined,
+      desiredStatus: undefined,
+      currentStatus: undefined,
+      stepsDone: undefined,
+      lastUpdated: undefined,
+      createdDate: undefined,
+      timesUsed: undefined,
+      integrationTemplateId: undefined,
+      id: undefined,
+      tags: undefined,
+      name: undefined
     };
+  }
 
-    createIntegrationRevision() {
-        return <IntegrationRevision > {
-            currentMessage: undefined,
-            parentVersion: undefined,
-            targetState: undefined,
-            targetMessage: undefined,
-            version: undefined,
-            spec: undefined,
-            currentState: undefined,
-        };
+  createIntegrationRevision() {
+    return <IntegrationRevision>{
+      currentMessage: undefined,
+      parentVersion: undefined,
+      targetState: undefined,
+      targetMessage: undefined,
+      version: undefined,
+      spec: undefined,
+      currentState: undefined
     };
+  }
 
-    createIntegrationRevisionSpec() {
-        return <IntegrationRevisionSpec > {
-            configuration: undefined,
-            steps: undefined,
-            connections: undefined,
-        };
+  createIntegrationRevisionSpec() {
+    return <IntegrationRevisionSpec>{
+      configuration: undefined,
+      steps: undefined,
+      connections: undefined
     };
+  }
 
-    createOrganization() {
-        return <Organization > {
-            environments: undefined,
-            users: undefined,
-            id: undefined,
-            name: undefined,
-        };
+  createOrganization() {
+    return <Organization>{
+      environments: undefined,
+      users: undefined,
+      id: undefined,
+      name: undefined
     };
+  }
 
-    createPropertyValue() {
-        return <PropertyValue > {
-            value: undefined,
-            label: undefined,
-        };
+  createPropertyValue() {
+    return <PropertyValue>{
+      value: undefined,
+      label: undefined
     };
+  }
 
-    createStep() {
-        return <Step > {
-            action: undefined,
-            connection: undefined,
-            name: undefined,
-            configuredProperties: undefined,
-            stepKind: undefined,
-            id: undefined,
-        };
+  createStep() {
+    return <Step>{
+      action: undefined,
+      connection: undefined,
+      name: undefined,
+      configuredProperties: undefined,
+      stepKind: undefined,
+      id: undefined
     };
+  }
 
-    createUser() {
-        return <User > {
-            fullName: undefined,
-            name: undefined,
-            organizationId: undefined,
-            username: undefined,
-            firstName: undefined,
-            lastName: undefined,
-            integrations: undefined,
-            roleId: undefined,
-            id: undefined,
-        };
+  createUser() {
+    return <User>{
+      fullName: undefined,
+      name: undefined,
+      organizationId: undefined,
+      username: undefined,
+      firstName: undefined,
+      lastName: undefined,
+      integrations: undefined,
+      roleId: undefined,
+      id: undefined
     };
+  }
 
-    createListResult() {
-        return <ListResult > {
-            items: undefined,
-            totalCount: undefined,
-        };
+  createListResult() {
+    return <ListResult>{
+      items: undefined,
+      totalCount: undefined
     };
+  }
 
-    createListResultWithIdObject() {
-        return <ListResultWithIdObject > {
-            items: undefined,
-            totalCount: undefined,
-        };
+  createListResultWithIdObject() {
+    return <ListResultWithIdObject>{
+      items: undefined,
+      totalCount: undefined
     };
+  }
 
-    createWithId() {
-        return <WithId > {
-            id: undefined,
-        };
+  createWithId() {
+    return <WithId>{
+      id: undefined
     };
+  }
 
-    createWithIdObject() {
-        return <WithIdObject > {
-            id: undefined,
-        };
+  createWithIdObject() {
+    return <WithIdObject>{
+      id: undefined
     };
+  }
 
-    createViolation() {
-        return <Violation > {};
+  createViolation() {
+    return <Violation>{};
+  }
+
+  createListResultAction() {
+    return <ListResultAction>{
+      items: undefined,
+      totalCount: undefined
     };
+  }
 
-    createListResultAction() {
-        return <ListResultAction > {
-            items: undefined,
-            totalCount: undefined,
-        };
+  createAcquisitionMethod() {
+    return <AcquisitionMethod>{
+      icon: undefined,
+      type: undefined,
+      description: undefined,
+      label: undefined
     };
+  }
 
-    createAcquisitionMethod() {
-        return <AcquisitionMethod > {
-            icon: undefined,
-            type: undefined,
-            description: undefined,
-            label: undefined,
-        };
+  createAcquisitionRequest() {
+    return <AcquisitionRequest>{
+      returnUrl: undefined
     };
+  }
 
-    createAcquisitionRequest() {
-        return <AcquisitionRequest > {
-            returnUrl: undefined,
-        };
+  createError() {
+    return <Error>{
+      parameters: undefined,
+      attributes: undefined,
+      description: undefined,
+      code: undefined
     };
+  }
 
-    createError() {
-        return <Error > {
-            parameters: undefined,
-            attributes: undefined,
-            description: undefined,
-            code: undefined,
-        };
+  createResult() {
+    return <Result>{
+      scope: undefined,
+      errors: undefined,
+      status: undefined
     };
+  }
 
-    createResult() {
-        return <Result > {
-            scope: undefined,
-            errors: undefined,
-            status: undefined,
-        };
+  createFilterOptions() {
+    return <FilterOptions>{
+      paths: undefined,
+      ops: undefined
     };
+  }
 
-    createFilterOptions() {
-        return <FilterOptions > {
-            paths: undefined,
-            ops: undefined,
-        };
+  createOp() {
+    return <Op>{
+      label: undefined,
+      operator: undefined
     };
+  }
 
-    createOp() {
-        return <Op > {
-            label: undefined,
-            operator: undefined,
-        };
+  createEventMessage() {
+    return <EventMessage>{
+      data: undefined,
+      event: undefined
     };
+  }
 
-    createEventMessage() {
-        return <EventMessage > {
-            data: undefined,
-            event: undefined,
-        };
+  createOAuthApp() {
+    return <OAuthApp>{
+      id: undefined,
+      name: undefined,
+      icon: undefined,
+      clientId: undefined,
+      clientSecret: undefined
     };
+  }
 
-    createOAuthApp() {
-        return <OAuthApp > {
-            id: undefined,
-            name: undefined,
-            icon: undefined,
-            clientId: undefined,
-            clientSecret: undefined,
-        };
+  createListResultString() {
+    return <ListResultString>{
+      items: undefined,
+      totalCount: undefined
     };
-
-    createListResultString() {
-        return <ListResultString > {
-            items: undefined,
-            totalCount: undefined,
-        };
-    };
-
-};
+  }
+}
 
 export const TypeFactory = new TypeFactoryClass();

--- a/src/app/settings/oauth-apps/oauth-app-form.component.ts
+++ b/src/app/settings/oauth-apps/oauth-app-form.component.ts
@@ -4,7 +4,7 @@ import {
   EventEmitter,
   Input,
   Output,
-  ChangeDetectorRef,
+  ChangeDetectorRef
 } from '@angular/core';
 import { OAuthApp, OAuthApps } from '../../model';
 import { FormFactoryService } from '../../common/forms.service';
@@ -13,7 +13,7 @@ import { FormGroup } from '@angular/forms';
 import {
   DynamicFormControlModel,
   DynamicFormService,
-  DynamicInputModel,
+  DynamicInputModel
 } from '@ng-dynamic-forms/core';
 
 // Default form config object for OAuth client settings
@@ -21,18 +21,18 @@ const OAUTH_APP_FORM_CONFIG = {
   clientId: {
     displayName: 'Client ID',
     type: 'string',
-    description: 'The OAuth client ID setting for the target application',
+    description: 'The OAuth client ID setting for the target application'
   },
   clientSecret: {
     displayName: 'Client Secret',
     type: 'password',
-    description: 'The OAuth client secret value for the target application',
-  },
+    description: 'The OAuth client secret value for the target application'
+  }
 };
 
 @Component({
   selector: 'syndesis-oauth-app-form',
-  templateUrl: 'oauth-app-form.component.html',
+  templateUrl: 'oauth-app-form.component.html'
 })
 export class OAuthAppFormComponent implements OnInit {
   @Input() item: any = {};
@@ -47,7 +47,7 @@ export class OAuthAppFormComponent implements OnInit {
     private formFactory: FormFactoryService,
     private formService: DynamicFormService,
     private store: OAuthAppStore,
-    public detector: ChangeDetectorRef,
+    public detector: ChangeDetectorRef
   ) {}
 
   save() {
@@ -71,13 +71,16 @@ export class OAuthAppFormComponent implements OnInit {
         this.error = error;
         sub.unsubscribe();
         this.detector.detectChanges();
-      },
+      }
     );
   }
 
   ngOnInit() {
     const formConfig = JSON.parse(JSON.stringify(OAUTH_APP_FORM_CONFIG));
-    this.formModel = this.formFactory.createFormModel(formConfig, this.item.client);
+    this.formModel = this.formFactory.createFormModel(
+      formConfig,
+      this.item.client
+    );
     this.formGroup = this.formService.createFormGroup(this.formModel);
   }
 }

--- a/src/app/settings/oauth-apps/oauth-app-modal.component.ts
+++ b/src/app/settings/oauth-apps/oauth-app-modal.component.ts
@@ -8,43 +8,51 @@ import { ModalService } from '../../common/modal/modal.service';
 
 @Component({
   selector: 'syndesis-oauth-app-modal',
-  templateUrl: './oauth-app-modal.component.html',
+  templateUrl: './oauth-app-modal.component.html'
 })
 export class OAuthAppModalComponent {
-
   // Holds the candidate for clearing credentials
   item: OAuthAppListItem;
   constructor(
     public store: OAuthAppStore,
     public detector: ChangeDetectorRef,
     private modalService: ModalService,
-    private notificationService: NotificationService,
+    private notificationService: NotificationService
   ) {}
 
   show(item: OAuthAppListItem) {
     this.item = item;
-    this.modalService.show()
-      .then(modal => modal.result
-        ? this.removeCredentials()
-          .then(app => this.item.client = app)
-          .then(_ => this.popNotification({
-              type: NotificationType.SUCCESS,
-              header: 'Delete Successful',
-              message: 'Settings successfully deleted.',
-            }))
-          .catch(error => this.popNotification({
-              type: NotificationType.DANGER,
-              header: 'Delete Failed',
-              message: `Failed to delete settings: ${error}`,
-            }))
-          .then(_ => this.detector.markForCheck())
-        : undefined);
+    this.modalService.show().then(
+      modal =>
+        modal.result
+          ? this.removeCredentials()
+              .then(app => (this.item.client = app))
+              .then(_ =>
+                this.popNotification({
+                  type: NotificationType.SUCCESS,
+                  header: 'Delete Successful',
+                  message: 'Settings successfully deleted.'
+                })
+              )
+              .catch(error =>
+                this.popNotification({
+                  type: NotificationType.DANGER,
+                  header: 'Delete Failed',
+                  message: `Failed to delete settings: ${error}`
+                })
+              )
+              .then(_ => this.detector.markForCheck())
+          : undefined
+    );
   }
 
   // Clear the store credentials for the selected oauth app
   removeCredentials() {
     const app = { ...this.item.client, clientId: '', clientSecret: '' };
-    return this.store.update(app).take(1).toPromise();
+    return this.store
+      .update(app)
+      .take(1)
+      .toPromise();
   }
 
   popNotification(notification) {
@@ -54,7 +62,7 @@ export class OAuthAppModalComponent {
       notification.message,
       false,
       null,
-      [],
+      []
     );
   }
 }

--- a/src/app/settings/oauth-apps/oauth-apps.component.ts
+++ b/src/app/settings/oauth-apps/oauth-apps.component.ts
@@ -17,7 +17,7 @@ export interface OAuthAppListItem {
 @Component({
   selector: 'syndesis-oauth-apps',
   templateUrl: 'oauth-apps.component.html',
-  styleUrls: [ './oauth-apps.component.scss' ],
+  styleUrls: ['./oauth-apps.component.scss']
 })
 export class OAuthAppsComponent implements OnInit {
   // Holds the candidate for clearing credentials
@@ -25,17 +25,17 @@ export class OAuthAppsComponent implements OnInit {
   // Pipe configuration
   filter: ObjectPropertyFilterConfig = {
     filter: '',
-    propertyName: 'client.name',
+    propertyName: 'client.name'
   };
   sort: ObjectPropertySortConfig = {
     sortField: 'client.name',
-    descending: false,
+    descending: false
   };
   // List configuration
   listConfig = {
     multiSelect: false,
     selectItems: false,
-    showCheckbox: false,
+    showCheckbox: false
   };
   // Toolbar configuration
   toolbarConfig = {
@@ -45,20 +45,20 @@ export class OAuthAppsComponent implements OnInit {
           id: 'client.name',
           title: 'Name',
           placeholder: 'Filter by Name...',
-          type: 'text',
-        },
-      ],
+          type: 'text'
+        }
+      ]
     },
     sortConfig: {
       fields: [
         {
           id: 'client.name',
           title: 'Name',
-          sortType: 'alpha',
-        },
+          sortType: 'alpha'
+        }
       ],
-      isAscending: true,
-    },
+      isAscending: true
+    }
   };
   // Data
   list: Observable<OAuthApps>;
@@ -67,11 +67,13 @@ export class OAuthAppsComponent implements OnInit {
 
   items: Array<OAuthAppListItem> = [];
 
-  constructor(public store: OAuthAppStore,
-              public detector: ChangeDetectorRef,
-              public config: ConfigService,
-              public tourService: TourService,
-              private userService: UserService) {
+  constructor(
+    public store: OAuthAppStore,
+    public detector: ChangeDetectorRef,
+    public config: ConfigService,
+    public tourService: TourService,
+    private userService: UserService
+  ) {
     this.loading = store.loading;
     this.list = store.list;
   }
@@ -115,7 +117,7 @@ export class OAuthAppsComponent implements OnInit {
         });
         this.items.push({
           expanded: oldApp ? oldApp.expanded : false,
-          client: app,
+          client: app
         });
       }
     });
@@ -125,17 +127,21 @@ export class OAuthAppsComponent implements OnInit {
      * If guided tour state is set to be shown (i.e. true), then show it for this page, otherwise don't.
      */
     if (this.userService.getTourState() === true) {
-      this.tourService.initialize([ {
-          route: 'settings',
-          title: 'Get Started',
-          content: 'This series of popups acquaints you with Fuse Ignite. When you are ready to create a sample integration, ' +
-          'click the help icon and select Documentation to get step-by-step instructions.',
-          anchorId: 'get.started',
-          placement: 'bottom',
-        } ],
+      this.tourService.initialize(
+        [
+          {
+            route: 'settings',
+            title: 'Get Started',
+            content:
+              'This series of popups acquaints you with Fuse Ignite. When you are ready to create a sample integration, ' +
+              'click the help icon and select Documentation to get step-by-step instructions.',
+            anchorId: 'get.started',
+            placement: 'bottom'
+          }
+        ],
         {
-          route: '',
-        },
+          route: ''
+        }
       );
 
       setTimeout(() => this.tourService.start());

--- a/src/app/settings/settings-root.component.ts
+++ b/src/app/settings/settings-root.component.ts
@@ -4,7 +4,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 @Component({
   selector: 'syndesis-settings-root',
   templateUrl: 'settings-root.component.html',
-  styleUrls: ['./settings-root.component.scss'],
+  styleUrls: ['./settings-root.component.scss']
 })
 export class SettingsRootComponent {
   constructor(private route: ActivatedRoute, private router: Router) {}

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -19,14 +19,14 @@ const routes: Routes = [
     children: [
       {
         path: 'oauth-clients',
-        component: OAuthAppsComponent,
+        component: OAuthAppsComponent
       },
       {
         path: '',
-        redirectTo: 'oauth-clients',
-      },
-    ],
-  },
+        redirectTo: 'oauth-clients'
+      }
+    ]
+  }
 ];
 
 @NgModule({
@@ -39,15 +39,15 @@ const routes: Routes = [
     ListModule,
     ToolbarModule,
     RouterModule.forChild(routes),
-    SyndesisCommonModule,
+    SyndesisCommonModule
   ],
   exports: [],
   declarations: [
     SettingsRootComponent,
     OAuthAppsComponent,
     OAuthAppFormComponent,
-    OAuthAppModalComponent,
+    OAuthAppModalComponent
   ],
-  providers: [],
+  providers: []
 })
 export class SettingsModule {}

--- a/src/app/store/connection/connection.service.ts
+++ b/src/app/store/connection/connection.service.ts
@@ -7,7 +7,6 @@ import { Connection, Connections, TypeFactory } from '../../model';
 
 @Injectable()
 export class ConnectionService extends RESTService<Connection, Connections> {
-
   private validationService;
 
   constructor(restangular: Restangular) {
@@ -22,10 +21,11 @@ export class ConnectionService extends RESTService<Connection, Connections> {
       .post(connection)
       .toPromise()
       .then(response => null)
-      .catch(response => response.data.reduce((errors, item) => {
-        errors[item.error] = true;
-        return errors;
-      }, {}));
+      .catch(response =>
+        response.data.reduce((errors, item) => {
+          errors[item.error] = true;
+          return errors;
+        }, {})
+      );
   }
-
 }

--- a/src/app/store/connection/connection.store.ts
+++ b/src/app/store/connection/connection.store.ts
@@ -13,7 +13,7 @@ export class ConnectionStore extends AbstractStore<
 > {
   constructor(
     connectionService: ConnectionService,
-    eventService: EventsService,
+    eventService: EventsService
   ) {
     super(connectionService, eventService, [], <Connection>{});
   }

--- a/src/app/store/connector/connector.service.ts
+++ b/src/app/store/connector/connector.service.ts
@@ -24,11 +24,17 @@ export class ConnectorService extends RESTService<Connector, Connectors> {
   }
 
   validate(id: string, data: Map<string, string>) {
-    return this.restangularService.one(id).one('verifier').customPOST(data);
+    return this.restangularService
+      .one(id)
+      .one('verifier')
+      .customPOST(data);
   }
 
   credentials(id: string) {
-    return this.restangularService.one(id).one('credentials').get();
+    return this.restangularService
+      .one(id)
+      .one('credentials')
+      .get();
   }
 
   acquireCredentials(id: string) {
@@ -44,7 +50,7 @@ export class ConnectorService extends RESTService<Connector, Connectors> {
               .replace(/^ +/, '')
               .replace(
                 /=.*/,
-                '=;expires=' + new Date().toUTCString() + ';path=/',
+                '=;expires=' + new Date().toUTCString() + ';path=/'
               );
           }
         });
@@ -53,7 +59,7 @@ export class ConnectorService extends RESTService<Connector, Connectors> {
           this.restangularService
             .one(id)
             .post('credentials', {
-              returnUrl: window.location.pathname + '#' + id,
+              returnUrl: window.location.pathname + '#' + id
             })
             .subscribe((resp: AcquisitionResponse) => {
               document.cookie = resp.state.spec;

--- a/src/app/store/entity/rest.service.ts
+++ b/src/app/store/entity/rest.service.ts
@@ -6,7 +6,7 @@ import { BaseEntity } from '../../model';
 export abstract class RESTService<T extends BaseEntity, L extends Array<T>> {
   protected constructor(
     public restangularService: Restangular,
-    public kind: String,
+    public kind: String
   ) {}
 
   get(id: string): Observable<T> {

--- a/src/app/store/integration-support.service.ts
+++ b/src/app/store/integration-support.service.ts
@@ -17,10 +17,12 @@ export class IntegrationSupportService {
   mapperService: Restangular = undefined;
   configService: ConfigService = undefined;
 
-  constructor(restangular: Restangular,
-              injector: Injector,
-              private http: Http,
-              private config: ConfigService) {
+  constructor(
+    restangular: Restangular,
+    injector: Injector,
+    private http: Http,
+    private config: ConfigService
+  ) {
     this.service = restangular.service('integration-support');
     this.filterService = restangular.service('integrations');
     this.metadataService = restangular.service('connections');
@@ -30,34 +32,57 @@ export class IntegrationSupportService {
   }
 
   getFilterOptions(dataShape: any): Observable<any> {
-    const url = this.filterService.one('filters').one('options').getRestangularUrl();
+    const url = this.filterService
+      .one('filters')
+      .one('options')
+      .getRestangularUrl();
     return this.http.post(url, dataShape);
   }
 
   requestPom(integration: Integration) {
-    const url = this.service.one('generate').one('pom.xml').getRestangularUrl();
+    const url = this.service
+      .one('generate')
+      .one('pom.xml')
+      .getRestangularUrl();
     return this.http.post(url, integration);
   }
 
-  fetchMetadata(connection: Connection, action: Action, configuredProperties: any) {
+  fetchMetadata(
+    connection: Connection,
+    action: Action,
+    configuredProperties: any
+  ) {
     const connectionId = connection.id;
     const actionId = action.id;
-    const url = this.metadataService.one(connectionId).one('actions').one(actionId).getRestangularUrl();
+    const url = this.metadataService
+      .one(connectionId)
+      .one('actions')
+      .one(actionId)
+      .getRestangularUrl();
     return this.http.post(url, configuredProperties);
   }
 
-  requestJavaInspection(connectorId: String, type: String): Observable<Response> {
-    const url = this.mapperService.one(connectorId).one(type + '.json').getRestangularUrl();
+  requestJavaInspection(
+    connectorId: String,
+    type: String
+  ): Observable<Response> {
+    const url = this.mapperService
+      .one(connectorId)
+      .one(type + '.json')
+      .getRestangularUrl();
     return this.http.get(url);
   }
 
   exportIntegration(id: string): Observable<Response> {
-    const url = this.config.getSettings().apiEndpoint + '/integrations/' + id + '/export.zip';
-    return this.http.get(url, {responseType: ResponseContentType.Blob});
+    const url =
+      this.config.getSettings().apiEndpoint +
+      '/integrations/' +
+      id +
+      '/export.zip';
+    return this.http.get(url, { responseType: ResponseContentType.Blob });
   }
 
   importIntegrationURL(): string {
     return this.service.one('import').getRestangularUrl();
   }
-
 }

--- a/src/app/store/integration/integration.store.ts
+++ b/src/app/store/integration/integration.store.ts
@@ -13,7 +13,7 @@ export class IntegrationStore extends AbstractStore<
 > {
   constructor(
     integrationService: IntegrationService,
-    eventService: EventsService,
+    eventService: EventsService
   ) {
     super(integrationService, eventService, [], <Integration>{});
   }

--- a/src/app/store/step/step.store.ts
+++ b/src/app/store/step/step.store.ts
@@ -8,7 +8,7 @@ export interface StepKind extends Step {
   visible?: (
     position: number,
     previous: Array<Step>,
-    subsequent: Array<Step>,
+    subsequent: Array<Step>
   ) => boolean;
 }
 export type StepKinds = Array<StepKind>;
@@ -36,10 +36,12 @@ export class StepStore {
       visible: (
         position: number,
         previousSteps: Array<Step>,
-        subsequentSteps: Array<Step>,
-      ) => this.stepsHaveOutputDataShape(previousSteps) && this.stepsHaveInputDataShape(subsequentSteps),
+        subsequentSteps: Array<Step>
+      ) =>
+        this.stepsHaveOutputDataShape(previousSteps) &&
+        this.stepsHaveInputDataShape(subsequentSteps),
       properties: {},
-      configuredProperties: undefined,
+      configuredProperties: undefined
     },
     {
       id: undefined,
@@ -51,7 +53,7 @@ export class StepStore {
         ' most integrations.',
       stepKind: BASIC_FILTER,
       properties: undefined,
-      configuredProperties: undefined,
+      configuredProperties: undefined
     },
     {
       id: undefined,
@@ -66,11 +68,11 @@ export class StepStore {
           type: 'textarea',
           displayName: 'Only continue if',
           required: true,
-          rows: 10,
-        },
+          rows: 10
+        }
       },
-      configuredProperties: undefined,
-    },
+      configuredProperties: undefined
+    }
     /*
     {
       id: undefined,
@@ -181,14 +183,24 @@ export class StepStore {
   }
 
   private stepsHaveOutputDataShape(steps: Array<Step>): boolean {
-    return steps
-      .filter(s => s.action && s.action.outputDataShape && s.action.outputDataShape.kind !== 'none')
-      .length > 0;
+    return (
+      steps.filter(
+        s =>
+          s.action &&
+          s.action.outputDataShape &&
+          s.action.outputDataShape.kind !== 'none'
+      ).length > 0
+    );
   }
 
   private stepsHaveInputDataShape(steps: Array<Step>): boolean {
-    return steps
-      .filter(s => s.action && s.action.inputDataShape && s.action.inputDataShape.kind !== 'none')
-      .length > 0;
+    return (
+      steps.filter(
+        s =>
+          s.action &&
+          s.action.inputDataShape &&
+          s.action.inputDataShape.kind !== 'none'
+      ).length > 0
+    );
   }
 }

--- a/src/app/store/store.module.ts
+++ b/src/app/store/store.module.ts
@@ -37,18 +37,18 @@ import { TestSupportService } from './test-support.service';
     TestSupportService,
     StepStore,
     OAuthAppService,
-    OAuthAppStore,
-  ],
+    OAuthAppStore
+  ]
 })
 export class StoreModule {
   constructor(
     @Optional()
     @SkipSelf()
-    parentModule: StoreModule,
+    parentModule: StoreModule
   ) {
     if (parentModule) {
       throw new Error(
-        'StoreModule is already loaded. Import it in the AppModule only',
+        'StoreModule is already loaded. Import it in the AppModule only'
       );
     }
   }

--- a/src/app/store/template/template.store.ts
+++ b/src/app/store/template/template.store.ts
@@ -13,7 +13,7 @@ export class TemplateStore extends AbstractStore<
 > {
   constructor(
     integrationService: TemplateService,
-    eventService: EventsService,
+    eventService: EventsService
   ) {
     super(integrationService, eventService, [], <IntegrationTemplate>{});
   }

--- a/src/app/store/test-support.service.ts
+++ b/src/app/store/test-support.service.ts
@@ -6,10 +6,7 @@ import { Restangular } from 'ngx-restangular';
 export class TestSupportService {
   service: Restangular = undefined;
 
-  constructor(
-    public restangular: Restangular,
-    public http: Http,
-  ) {
+  constructor(public restangular: Restangular, public http: Http) {
     this.service = restangular.service('test-support');
   }
 

--- a/src/app/templates/list-page/list-page.component.spec.ts
+++ b/src/app/templates/list-page/list-page.component.spec.ts
@@ -22,12 +22,12 @@ describe('TemplatesListPage', () => {
           SyndesisCommonModule.forRoot(),
           StoreModule,
           RestangularModule.forRoot(),
-          RouterTestingModule.withRoutes([]),
+          RouterTestingModule.withRoutes([])
         ],
         declarations: [
           TemplatesListPage,
           ListToolbarComponent,
-          TemplatesListComponent,
+          TemplatesListComponent
         ],
         providers: [
           MockBackend,
@@ -37,11 +37,11 @@ describe('TemplatesListPage', () => {
             useFactory: (backend, options) => {
               return new Http(backend, options);
             },
-            deps: [MockBackend, RequestOptions],
-          },
-        ],
+            deps: [MockBackend, RequestOptions]
+          }
+        ]
       }).compileComponents();
-    }),
+    })
   );
 
   beforeEach(() => {

--- a/src/app/templates/list-page/list-page.component.ts
+++ b/src/app/templates/list-page/list-page.component.ts
@@ -7,7 +7,7 @@ import { IntegrationTemplates } from '../../model';
 @Component({
   selector: 'syndesis-templates-list-page',
   templateUrl: './list-page.component.html',
-  styleUrls: ['./list-page.component.scss'],
+  styleUrls: ['./list-page.component.scss']
 })
 export class TemplatesListPage implements OnInit {
   templates: Observable<IntegrationTemplates>;

--- a/src/app/templates/list-toolbar/list-toolbar.component.scss
+++ b/src/app/templates/list-toolbar/list-toolbar.component.scss
@@ -1,1 +1,2 @@
-.list-toolbar {}
+.list-toolbar {
+}

--- a/src/app/templates/list-toolbar/list-toolbar.component.spec.ts
+++ b/src/app/templates/list-toolbar/list-toolbar.component.spec.ts
@@ -12,9 +12,9 @@ describe('ListToolbarComponent', () => {
   beforeEach(
     async(() => {
       TestBed.configureTestingModule({
-        declarations: [ListToolbarComponent],
+        declarations: [ListToolbarComponent]
       }).compileComponents();
-    }),
+    })
   );
 
   beforeEach(() => {

--- a/src/app/templates/list-toolbar/list-toolbar.component.ts
+++ b/src/app/templates/list-toolbar/list-toolbar.component.ts
@@ -3,6 +3,6 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'syndesis-templates-list-toolbar',
   templateUrl: './list-toolbar.component.html',
-  styleUrls: ['./list-toolbar.component.scss'],
+  styleUrls: ['./list-toolbar.component.scss']
 })
 export class ListToolbarComponent {}

--- a/src/app/templates/list/list.component.spec.ts
+++ b/src/app/templates/list/list.component.spec.ts
@@ -14,11 +14,11 @@ describe('TemplatesListComponent', () => {
       TestBed.configureTestingModule({
         imports: [
           SyndesisCommonModule.forRoot(),
-          RouterTestingModule.withRoutes([]),
+          RouterTestingModule.withRoutes([])
         ],
-        declarations: [TemplatesListComponent],
+        declarations: [TemplatesListComponent]
       }).compileComponents();
-    }),
+    })
   );
 
   beforeEach(() => {

--- a/src/app/templates/list/list.component.ts
+++ b/src/app/templates/list/list.component.ts
@@ -5,7 +5,7 @@ import { IntegrationTemplates } from '../../model';
 @Component({
   selector: 'syndesis-templates-list',
   templateUrl: './list.component.html',
-  styleUrls: ['./list.component.scss'],
+  styleUrls: ['./list.component.scss']
 })
 export class TemplatesListComponent {
   @Input() templates: IntegrationTemplates;

--- a/src/app/templates/templates-routes.module.ts
+++ b/src/app/templates/templates-routes.module.ts
@@ -5,10 +5,10 @@ import { TemplatesModule } from './templates.module';
 import { TemplatesListPage } from './list-page/list-page.component';
 
 const routes: Routes = [
-  { path: '', component: TemplatesListPage, pathMatch: 'full' },
+  { path: '', component: TemplatesListPage, pathMatch: 'full' }
 ];
 
 @NgModule({
-  imports: [RouterModule.forChild(routes), TemplatesModule],
+  imports: [RouterModule.forChild(routes), TemplatesModule]
 })
 export class TemplateRoutesModule {}

--- a/src/app/templates/templates.module.ts
+++ b/src/app/templates/templates.module.ts
@@ -13,8 +13,8 @@ import { TemplatesListComponent } from './list/list.component';
   declarations: [
     TemplatesListPage,
     TemplatesListComponent,
-    ListToolbarComponent,
+    ListToolbarComponent
   ],
-  exports: [TemplatesListComponent],
+  exports: [TemplatesListComponent]
 })
 export class TemplatesModule {}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  config: {},
+  config: {}
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -12,7 +12,7 @@ export const environment = Object.freeze({
       baseJavaInspectionServiceUrl: 'http://localhost:8585/v2/atlas/java/',
       baseXMLInspectionServiceUrl: 'http://localhost:8585/v2/atlas/xml/',
       baseJSONInspectionServiceUrl: 'http://localhost:8585/v2/atlas/json/',
-      baseMappingServiceUrl: 'http://localhost:8585/v2/atlas/',
-    },
-  },
+      baseMappingServiceUrl: 'http://localhost:8585/v2/atlas/'
+    }
+  }
 });

--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -27,8 +27,8 @@ a.disabled {
   display: flex;
   flex-direction: row;
 
-  [class^="col-"],
-  [class*=" col-"] {
+  [class^='col-'],
+  [class*=' col-'] {
     display: flex;
     align-items: center;
     //justify-content: center; /* Optional, to align inner items horizontally inside the column */

--- a/src/scss/_overrides.scss
+++ b/src/scss/_overrides.scss
@@ -7,7 +7,7 @@
 // This is the darker gray we are using as a result of the lighter grays in PatternFly
 // getting washed out on projectors, demo recordings, and BlueJeans screenshares.
 
-$color-pf-custom-gray:           #E1E1E1;
+$color-pf-custom-gray: #e1e1e1;
 
 body.cards-pf {
   background-color: $color-pf-custom-gray;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,6 +2,7 @@
 @import 'scss/overrides';
 @import 'scss/forms';
 
-html, body {
+html,
+body {
   height: 100%;
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -9,7 +9,7 @@ import 'zone.js/dist/fake-async-test';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
+  platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
@@ -23,7 +23,7 @@ __karma__.loaded = function() {};
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting(),
+  platformBrowserDynamicTesting()
 );
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);


### PR DESCRIPTION
This is seemingly abusive for someone to have to review. @gashcrumb this is simply the compiled/transpiled result of running `yarn format` to comply with Prettier rules we have defined, and to ensure that it plays well with `yarn lint`.

fix #1220 