### PR TITLE
Add distribution management section.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,18 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+  <distributionManagement>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+      <uniqueVersion>false</uniqueVersion>
+    </repository>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+
   <properties>
     <clean-maven-plugin-version>2.4.1</clean-maven-plugin-version>
     <frontend-maven-plugin-version>1.6</frontend-maven-plugin-version>


### PR DESCRIPTION
Add a distribution management section to syndesis-ui - there is a bug in the nexus staging plugin that sometimes requires a default one to exist.

https://issues.sonatype.org/browse/NEXUS-14460
